### PR TITLE
Fix: Rename Automation chapter to avoid naming conflict with lesson

### DIFF
--- a/data/sheets/index.ts
+++ b/data/sheets/index.ts
@@ -2036,7 +2036,7 @@ export const cheatSheets: CheatSheet[] = [
   {
     id: "automation",
     header: {
-      title: "Automation: Beyond Volume",
+      title: "Automation",
       subtitle: "Advanced automation techniques for dynamic, musical mixes",
       icon: "🎛️",
       accent: "purple"

--- a/ios/LogicProCheatSheets/LogicProCheatSheets/Resources/SeedContent.json
+++ b/ios/LogicProCheatSheets/LogicProCheatSheets/Resources/SeedContent.json
@@ -133,8 +133,8 @@
     {
       "id": "automation",
       "href": "/sheets/automation",
-      "label": "Automation: Beyond Volume",
-      "title": "Automation: Beyond Volume",
+      "label": "Automation",
+      "title": "Automation",
       "icon": "🎛️"
     },
     {
@@ -4203,7 +4203,7 @@
     {
       "id": "automation",
       "header": {
-        "title": "Automation: Beyond Volume",
+        "title": "Automation",
         "subtitle": "Advanced automation techniques for dynamic, musical mixes",
         "icon": "🎛️",
         "accent": "purple"

--- a/public/content/content.json
+++ b/public/content/content.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "contentVersion": "20260509T224138Z",
-  "generatedAt": "2026-05-09T22:41:38.696Z",
+  "contentVersion": "20260510T145536Z",
+  "generatedAt": "2026-05-10T14:55:36.758Z",
   "minAppVersion": "1.0.0",
   "navItems": [
     {
@@ -133,8 +133,8 @@
     {
       "id": "automation",
       "href": "/sheets/automation",
-      "label": "Automation: Beyond Volume",
-      "title": "Automation: Beyond Volume",
+      "label": "Automation",
+      "title": "Automation",
       "icon": "🎛️"
     },
     {
@@ -4203,7 +4203,7 @@
     {
       "id": "automation",
       "header": {
-        "title": "Automation: Beyond Volume",
+        "title": "Automation",
         "subtitle": "Advanced automation techniques for dynamic, musical mixes",
         "icon": "🎛️",
         "accent": "purple"

--- a/public/content/en/content.json
+++ b/public/content/en/content.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "contentVersion": "20260509T224138Z",
-  "generatedAt": "2026-05-09T22:41:38.696Z",
+  "contentVersion": "20260510T145536Z",
+  "generatedAt": "2026-05-10T14:55:36.758Z",
   "minAppVersion": "1.0.0",
   "navItems": [
     {
@@ -133,8 +133,8 @@
     {
       "id": "automation",
       "href": "/sheets/automation",
-      "label": "Automation: Beyond Volume",
-      "title": "Automation: Beyond Volume",
+      "label": "Automation",
+      "title": "Automation",
       "icon": "🎛️"
     },
     {
@@ -4203,7 +4203,7 @@
     {
       "id": "automation",
       "header": {
-        "title": "Automation: Beyond Volume",
+        "title": "Automation",
         "subtitle": "Advanced automation techniques for dynamic, musical mixes",
         "icon": "🎛️",
         "accent": "purple"

--- a/public/content/en/manifest.json
+++ b/public/content/en/manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "contentVersion": "20260509T224138Z",
-  "generatedAt": "2026-05-09T22:41:38.696Z",
+  "contentVersion": "20260510T145536Z",
+  "generatedAt": "2026-05-10T14:55:36.758Z",
   "minAppVersion": "1.0.0",
   "bundle": {
     "url": "/content/en/content.json",
-    "sha256": "f95318d1403a2b8623956ee6da424e3a8ed8905a66f84e4fc21bd97daa867258",
-    "bytes": 811771
+    "sha256": "c1f89a552e57f622a09adc6bdce6144f9dd2bba80f4a946ac61536421f8465d1",
+    "bytes": 811726
   }
 }

--- a/public/content/manifest.json
+++ b/public/content/manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "contentVersion": "20260509T224138Z",
-  "generatedAt": "2026-05-09T22:41:38.696Z",
+  "contentVersion": "20260510T145536Z",
+  "generatedAt": "2026-05-10T14:55:36.758Z",
   "minAppVersion": "1.0.0",
   "bundle": {
     "url": "/content/content.json",
-    "sha256": "f95318d1403a2b8623956ee6da424e3a8ed8905a66f84e4fc21bd97daa867258",
-    "bytes": 811771
+    "sha256": "c1f89a552e57f622a09adc6bdce6144f9dd2bba80f4a946ac61536421f8465d1",
+    "bytes": 811726
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves issue LEV-18

This PR fixes a naming conflict where "Automation: Beyond Volume" was used as both a chapter name and a lesson name, despite containing different material.

## Changes

- Renamed the **chapter** title from "Automation: Beyond Volume" to "Automation"
- Kept the **lesson** title as "Automation: Beyond Volume" (unchanged)
- Updated source data in `data/sheets/index.ts`
- Regenerated exported content files (`public/content/`)
- Updated iOS seed content file to match

## Testing

The changes have been verified:
- Chapter navigation now shows "Automation" instead of "Automation: Beyond Volume"
- Lesson still displays "Automation: Beyond Volume" as intended
- No other references were affected

## Files Changed

- `data/sheets/index.ts` - Updated chapter header title
- `public/content/content.json` - Regenerated with new chapter name
- `public/content/en/content.json` - Regenerated with new chapter name
- `ios/LogicProCheatSheets/LogicProCheatSheets/Resources/SeedContent.json` - Updated chapter references
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LEV-18](https://linear.app/levensailor/issue/LEV-18/chapter-vs-lessons)

<div><a href="https://cursor.com/agents/bc-1ba239a0-a6b9-4e80-b950-83d42c6522a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ba239a0-a6b9-4e80-b950-83d42c6522a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

