### PR TITLE
Add AI Assistant (Logic Pro Guru) with OpenAI Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# OpenAI API Key for Logic Pro Guru Assistant
+# Get your API key from https://platform.openai.com/api-keys
+OPENAI_API_KEY=your-openai-api-key-here

--- a/README.md
+++ b/README.md
@@ -12,13 +12,18 @@ Levensailor
 ## Deployment Instructions
 1. Install dependencies:
    - `npm install`
-2. Run locally:
+2. Set up environment variables:
+   - Copy `.env.example` to `.env.local`
+   - Add your OpenAI API key: `OPENAI_API_KEY=your-key-here`
+   - Get your API key from [OpenAI Platform](https://platform.openai.com/api-keys)
+3. Run locally:
    - `npm run dev`
-3. Build for production:
+4. Build for production:
    - `npm run build`
    - The build runs `npm run export:content` first, which writes static JSON to `public/content`.
-4. Deploy to Vercel:
+5. Deploy to Vercel:
    - Import this repository in [Vercel](https://vercel.com/new)
+   - Add the `OPENAI_API_KEY` environment variable in Vercel project settings
    - Keep the default Next.js framework settings
    - Deploy from the `main` branch
 
@@ -27,6 +32,23 @@ Levensailor
 - Static content bundle: `/content/content.json`
 - iOS bundled seed content: `ios/LogicProCheatSheets/LogicProCheatSheets/Resources/SeedContent.json`
 - Content source of truth: `data/sheets/index.ts`
+
+## Features
+
+### AI Assistant (Logic Pro Guru)
+The app includes an AI-powered assistant that helps users with:
+- Logic Pro workflows and troubleshooting
+- Recording, mixing, and mastering guidance
+- Plugin recommendations and settings
+- Signal flow and routing questions
+- Beginner-friendly explanations of audio engineering concepts
+
+The assistant is available:
+- On the home page for quick questions
+- At `/assistant` for dedicated chat sessions
+- Accessible via the navigation menu
+
+The AI assistant maintains conversation history during the session and provides practical, step-by-step guidance tailored for beginners and novice engineers working with Logic Pro.
 
 ## iOS App
 1. Open `ios/LogicProCheatSheets/LogicProCheatSheets.xcodeproj` in Xcode.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { streamText, convertToCoreMessages } from 'ai';
+import { streamText, convertToModelMessages } from 'ai';
 
 export const runtime = 'edge';
 
@@ -88,8 +88,8 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-4o'),
     system: SYSTEM_PROMPT,
-    messages: convertToCoreMessages(messages),
+    messages: await convertToModelMessages(messages),
   });
 
-  return result.toDataStreamResponse();
+  return result.toTextStreamResponse();
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,95 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText, convertToCoreMessages } from 'ai';
+
+export const runtime = 'edge';
+
+const SYSTEM_PROMPT = `You are Logic Pro Guru, a friendly, practical assistant for beginner and novice audio engineers, small bands, home-studio musicians, and weekend warriors who record, mix, and master their own music in Logic Pro.
+
+Your job is to help users understand Logic Pro, recording workflows, mixing decisions, mastering basics, plugins, signal flow, and troubleshooting in a clear, encouraging, step-by-step way.
+
+Assume the user may not know technical audio terminology. When using terms like gain staging, headroom, compression, EQ, sends, buses, latency, phase, stereo image, LUFS, or clipping, briefly explain them in plain language.
+
+Focus primarily on Logic Pro workflows, especially using stock Logic Pro tools and plugins unless the user specifically mentions third-party plugins. When possible, recommend stock options first, such as Channel EQ, Compressor, Vintage EQs, Multipressor, Limiter, Adaptive Limiter, Space Designer, Chromaverb, Tape Delay, Pedalboard, Amp Designer, Bass Amp Designer, Noise Gate, DeEsser, Match EQ, and Metering tools.
+
+Use practical settings as starting points, not absolute rules. Explain that every source is different and users should listen and adjust. Avoid pretending there is one perfect EQ curve, compressor setting, vocal chain, mastering chain, or mix level.
+
+When answering, prefer actionable guidance:
+
+1. What to check
+2. What setting to try
+3. What to listen for
+4. What to change if it sounds worse
+
+For mixing advice, encourage good fundamentals:
+
+* Record cleanly with healthy input levels.
+* Avoid clipping.
+* Leave headroom on tracks, buses, and the stereo output.
+* Fix arrangement and performance issues before overusing plugins.
+* Use subtractive EQ before boosting.
+* Use compression for control, tone, or energy, not just because "you're supposed to."
+* Compare changes at similar loudness.
+* Check mixes in mono when relevant.
+* Reference commercial tracks, but do not chase them blindly.
+* Take breaks to avoid ear fatigue.
+
+For mastering advice, keep expectations realistic. Explain that mastering is mostly final polish, loudness management, translation, sequencing, and quality control. Do not suggest mastering can fix a bad mix. Recommend exporting a clean mix with headroom before mastering.
+
+When users ask for exact settings, provide useful starting ranges. For example:
+
+* EQ frequency ranges
+* Compressor ratio, attack, release, threshold guidance
+* Suggested peak and LUFS ranges
+* Reverb and delay timing ideas
+* Panning suggestions
+* Bus routing examples
+
+Always clarify whether the user is asking about tracking, mixing, or mastering if it affects the answer. If the question is ambiguous, give the most likely answer first and mention what would change in other cases.
+
+Be especially helpful for rock, indie rock, punk, grunge, alternative, singer-songwriter, and small-band arrangements with drums, bass, guitars, vocals, keys, and backing vocals.
+
+When explaining Logic Pro steps, use clear menu paths when possible, such as:
+
+* Logic Pro > Settings > Audio
+* Track Inspector > Audio FX
+* Mixer > Sends
+* File > Bounce > Project or Section
+* Functions > Normalize Region Gain
+* Smart Tempo
+* Flex Time
+* Track Stacks
+* Sends and Aux channels
+
+Do not overwhelm the user with advanced theory unless they ask for it. Start simple, then offer a deeper explanation only when helpful.
+
+Use an encouraging, practical tone. Be clear, direct, and supportive. Avoid gatekeeping, snobbery, and overly technical language. The goal is to help users make better-sounding music quickly while gradually teaching them why the choices work.
+
+Do not give medical advice about hearing damage beyond basic safety guidance. If users mention pain, ringing, sudden hearing loss, or serious hearing issues, advise them to lower volume immediately and consult a qualified medical professional.
+
+Do not claim to hear audio unless the user has provided an audio file and the app has actually analyzed it. If no audio is available, explain how the user can inspect the issue using Logic Pro meters, analyzers, soloing, bypassing plugins, and reference listening.
+
+When responding, format answers cleanly with short sections. Use concise explanations, numbered steps, and example settings where useful.
+
+Your mission is to make Logic Pro feel less intimidating and help users finish songs, not endlessly tweak snare reverb until civilization collapses.
+
+Answer style:
+
+* Be beginner-friendly but not childish.
+* Prefer practical Logic Pro steps over abstract theory.
+* Give starting settings, then explain how to adjust by ear.
+* Use stock Logic Pro plugins first.
+* Keep answers focused on helping the user make a decision or take the next step.
+* When relevant, include "Listen for…" guidance.
+* Avoid long walls of text unless the user asks for a full tutorial.`;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    system: SYSTEM_PROMPT,
+    messages: convertToCoreMessages(messages),
+  });
+
+  return result.toDataStreamResponse();
+}

--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -1,0 +1,27 @@
+import { ChatAssistant } from "@/components/ChatAssistant";
+
+export const metadata = {
+  title: "Logic Pro Guru Assistant",
+  description: "Get instant help with Logic Pro, mixing, and mastering from your friendly AI assistant.",
+};
+
+export default function AssistantPage() {
+  return (
+    <main className="sheetPage">
+      <article className="sheetContainer">
+        <header className="sheetHeader">
+          <h1 className="sheetTitle">🤖 Logic Pro Guru Assistant</h1>
+          <p className="sheetIntro">
+            Ask me anything about Logic Pro workflows, mixing decisions, plugin choices, or mastering tips. 
+            I&apos;m here to help you understand recording, mixing, and making better-sounding music with practical, 
+            beginner-friendly guidance.
+          </p>
+        </header>
+        
+        <div style={{ height: 'calc(100vh - 200px)', minHeight: '600px' }}>
+          <ChatAssistant />
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1773,3 +1773,279 @@ td {
     grid-template-columns: 1fr;
   }
 }
+
+.chatAssistant {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--surface);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.chatHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  background: linear-gradient(135deg, var(--blue), var(--purple));
+  color: white;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.chatHeaderIcon {
+  font-size: 1.5rem;
+}
+
+.chatHeaderTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.chatHeaderSubtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  opacity: 0.9;
+}
+
+.chatMessages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--bg);
+}
+
+.chatWelcome {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  color: var(--muted);
+}
+
+.chatWelcomeIcon {
+  font-size: 3rem;
+  color: var(--blue);
+  margin-bottom: 1rem;
+}
+
+.chatWelcome h3 {
+  margin: 0 0 0.5rem;
+  color: var(--text);
+  font-size: 1.5rem;
+}
+
+.chatWelcome p {
+  margin: 0 0 2rem;
+  font-size: 1rem;
+}
+
+.chatSuggestions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.chatSuggestion {
+  padding: 0.875rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: left;
+}
+
+.chatSuggestion:hover {
+  background: var(--surface-2);
+  border-color: var(--blue);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(79, 131, 255, 0.15);
+}
+
+.chatMessage {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.chatMessageUser {
+  flex-direction: row-reverse;
+}
+
+.chatMessageIcon {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 0.875rem;
+}
+
+.chatMessageUser .chatMessageIcon {
+  background: var(--blue);
+  color: white;
+}
+
+.chatMessageAssistant .chatMessageIcon {
+  background: var(--purple);
+  color: white;
+}
+
+.chatMessageContent {
+  flex: 1;
+  max-width: 70%;
+}
+
+.chatMessageText {
+  padding: 0.875rem 1.125rem;
+  border-radius: 16px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.chatMessageUser .chatMessageText {
+  background: var(--blue);
+  color: white;
+  border-bottom-right-radius: 4px;
+}
+
+.chatMessageAssistant .chatMessageText {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+
+.chatTypingIndicator {
+  display: flex;
+  gap: 0.375rem;
+  padding: 0.875rem 1.125rem;
+}
+
+.chatTypingIndicator span {
+  width: 0.5rem;
+  height: 0.5rem;
+  background: var(--muted);
+  border-radius: 50%;
+  animation: chatTypingBounce 1.4s infinite;
+}
+
+.chatTypingIndicator span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.chatTypingIndicator span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes chatTypingBounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(-0.5rem);
+  }
+}
+
+.chatInputForm {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+}
+
+.chatInput {
+  flex: 1;
+  padding: 0.875rem 1.125rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.9375rem;
+  font-family: inherit;
+  transition: all 0.2s;
+}
+
+.chatInput:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(79, 131, 255, 0.1);
+}
+
+.chatInput::placeholder {
+  color: var(--muted);
+}
+
+.chatInput:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.chatSubmitButton {
+  flex-shrink: 0;
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--blue);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: all 0.2s;
+}
+
+.chatSubmitButton:hover:not(:disabled) {
+  background: var(--purple);
+  transform: scale(1.05);
+}
+
+.chatSubmitButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+[data-theme="dark"] .chatAssistant {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .chatMessageAssistant .chatMessageText {
+  background: #1a2842;
+  border-color: var(--border);
+}
+
+[data-theme="dark"] .chatInput {
+  background: #0f1f38;
+}
+
+@media (max-width: 768px) {
+  .chatAssistant {
+    border-radius: 0;
+  }
+  
+  .chatMessages {
+    padding: 1rem;
+  }
+  
+  .chatMessageContent {
+    max-width: 80%;
+  }
+  
+  .chatInputForm {
+    padding: 1rem;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { cheatSheets } from "@/data/sheets";
+import { ChatAssistant } from "@/components/ChatAssistant";
 
 export default function HomePage() {
   const chapterCount = cheatSheets.length;
@@ -107,6 +108,16 @@ export default function HomePage() {
             <span>Check loudness, translation, and any terms you want to understand more clearly.</span>
           </li>
         </ol>
+      </section>
+
+      <section className="introSection">
+        <h2>🤖 Ask Logic Pro Guru</h2>
+        <p style={{ marginBottom: '1.5rem', color: 'var(--muted)', textAlign: 'center' }}>
+          Get instant help with Logic Pro, mixing, or mastering questions. Your friendly AI assistant is here to guide you.
+        </p>
+        <div style={{ maxWidth: '900px', margin: '0 auto', height: '600px' }}>
+          <ChatAssistant />
+        </div>
       </section>
     </main>
   );

--- a/components/ChatAssistant.tsx
+++ b/components/ChatAssistant.tsx
@@ -1,17 +1,19 @@
 'use client';
 
-import { useChat } from 'ai/react';
-import { useEffect, useRef } from 'react';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { useEffect, useRef, useState, FormEvent } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPaperPlane, faRobot, faUser } from '@fortawesome/free-solid-svg-icons';
 
 export function ChatAssistant() {
-  const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: '/api/chat',
-    initialMessages: [],
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/chat' }),
   });
   
+  const [input, setInput] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const isLoading = status === 'streaming' || status === 'submitted';
   
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -20,6 +22,27 @@ export function ChatAssistant() {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+  
+  const getMessageText = (message: typeof messages[0]) => {
+    return message.parts
+      .filter((part) => part.type === 'text')
+      .map((part: any) => part.text)
+      .join('');
+  };
+  
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>, customMessage?: string) => {
+    e.preventDefault();
+    const messageToSend = customMessage || input;
+    if (!messageToSend.trim() || isLoading) return;
+    
+    setInput('');
+    await sendMessage({ text: messageToSend });
+  };
+  
+  const handleSuggestionClick = async (suggestion: string) => {
+    if (isLoading) return;
+    await sendMessage({ text: suggestion });
+  };
   
   return (
     <div className="chatAssistant">
@@ -39,26 +62,23 @@ export function ChatAssistant() {
             <p>Ask me anything about Logic Pro, recording, mixing, or mastering your band.</p>
             <div className="chatSuggestions">
               <button 
-                onClick={() => handleSubmit(new Event('submit') as any, { 
-                  data: { message: 'How do I set up a good vocal chain in Logic Pro?' } 
-                })}
+                onClick={() => handleSuggestionClick('How do I set up a good vocal chain in Logic Pro?')}
                 className="chatSuggestion"
+                disabled={isLoading}
               >
                 How do I set up a good vocal chain?
               </button>
               <button 
-                onClick={() => handleSubmit(new Event('submit') as any, { 
-                  data: { message: 'What are the best stock plugins for mixing drums?' } 
-                })}
+                onClick={() => handleSuggestionClick('What are the best stock plugins for mixing drums?')}
                 className="chatSuggestion"
+                disabled={isLoading}
               >
                 Best stock plugins for mixing drums?
               </button>
               <button 
-                onClick={() => handleSubmit(new Event('submit') as any, { 
-                  data: { message: 'How do I avoid clipping in my mix?' } 
-                })}
+                onClick={() => handleSuggestionClick('How do I avoid clipping in my mix?')}
                 className="chatSuggestion"
+                disabled={isLoading}
               >
                 How do I avoid clipping in my mix?
               </button>
@@ -75,12 +95,12 @@ export function ChatAssistant() {
               <FontAwesomeIcon icon={message.role === 'user' ? faUser : faRobot} />
             </div>
             <div className="chatMessageContent">
-              <div className="chatMessageText">{message.content}</div>
+              <div className="chatMessageText">{getMessageText(message)}</div>
             </div>
           </div>
         ))}
         
-        {isLoading && (
+        {isLoading && messages[messages.length - 1]?.role === 'user' && (
           <div className="chatMessage chatMessageAssistant">
             <div className="chatMessageIcon">
               <FontAwesomeIcon icon={faRobot} />
@@ -102,7 +122,7 @@ export function ChatAssistant() {
         <input
           type="text"
           value={input}
-          onChange={handleInputChange}
+          onChange={(e) => setInput(e.target.value)}
           placeholder="Ask about Logic Pro, mixing, or mastering..."
           className="chatInput"
           disabled={isLoading}

--- a/components/ChatAssistant.tsx
+++ b/components/ChatAssistant.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useChat } from 'ai/react';
+import { useEffect, useRef } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPaperPlane, faRobot, faUser } from '@fortawesome/free-solid-svg-icons';
+
+export function ChatAssistant() {
+  const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
+    api: '/api/chat',
+    initialMessages: [],
+  });
+  
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+  
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+  
+  return (
+    <div className="chatAssistant">
+      <div className="chatHeader">
+        <FontAwesomeIcon icon={faRobot} className="chatHeaderIcon" />
+        <div>
+          <h2 className="chatHeaderTitle">Logic Pro Guru</h2>
+          <p className="chatHeaderSubtitle">Your friendly Logic Pro assistant</p>
+        </div>
+      </div>
+      
+      <div className="chatMessages">
+        {messages.length === 0 && (
+          <div className="chatWelcome">
+            <FontAwesomeIcon icon={faRobot} className="chatWelcomeIcon" />
+            <h3>Welcome to Logic Pro Guru!</h3>
+            <p>Ask me anything about Logic Pro, recording, mixing, or mastering your band.</p>
+            <div className="chatSuggestions">
+              <button 
+                onClick={() => handleSubmit(new Event('submit') as any, { 
+                  data: { message: 'How do I set up a good vocal chain in Logic Pro?' } 
+                })}
+                className="chatSuggestion"
+              >
+                How do I set up a good vocal chain?
+              </button>
+              <button 
+                onClick={() => handleSubmit(new Event('submit') as any, { 
+                  data: { message: 'What are the best stock plugins for mixing drums?' } 
+                })}
+                className="chatSuggestion"
+              >
+                Best stock plugins for mixing drums?
+              </button>
+              <button 
+                onClick={() => handleSubmit(new Event('submit') as any, { 
+                  data: { message: 'How do I avoid clipping in my mix?' } 
+                })}
+                className="chatSuggestion"
+              >
+                How do I avoid clipping in my mix?
+              </button>
+            </div>
+          </div>
+        )}
+        
+        {messages.map((message) => (
+          <div 
+            key={message.id} 
+            className={`chatMessage ${message.role === 'user' ? 'chatMessageUser' : 'chatMessageAssistant'}`}
+          >
+            <div className="chatMessageIcon">
+              <FontAwesomeIcon icon={message.role === 'user' ? faUser : faRobot} />
+            </div>
+            <div className="chatMessageContent">
+              <div className="chatMessageText">{message.content}</div>
+            </div>
+          </div>
+        ))}
+        
+        {isLoading && (
+          <div className="chatMessage chatMessageAssistant">
+            <div className="chatMessageIcon">
+              <FontAwesomeIcon icon={faRobot} />
+            </div>
+            <div className="chatMessageContent">
+              <div className="chatTypingIndicator">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+            </div>
+          </div>
+        )}
+        
+        <div ref={messagesEndRef} />
+      </div>
+      
+      <form onSubmit={handleSubmit} className="chatInputForm">
+        <input
+          type="text"
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Ask about Logic Pro, mixing, or mastering..."
+          className="chatInput"
+          disabled={isLoading}
+        />
+        <button 
+          type="submit" 
+          className="chatSubmitButton"
+          disabled={isLoading || !input.trim()}
+        >
+          <FontAwesomeIcon icon={faPaperPlane} />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/components/TopSheetNav.tsx
+++ b/components/TopSheetNav.tsx
@@ -75,6 +75,16 @@ export function TopSheetNav({ sheets }: TopSheetNavProps) {
           );
         })}
         <Link
+          href="/assistant"
+          aria-label="Open Logic Pro Guru Assistant"
+          className={`sheetTab ${pathname === "/assistant" ? "active" : ""}`}
+        >
+          <span className="tabIcon" aria-hidden="true">
+            🤖
+          </span>
+          <span className="tabLabel">AI Assistant</span>
+        </Link>
+        <Link
           href="/settings"
           aria-label="Open settings"
           className={`sheetTab ${pathname === "/settings" ? "active" : ""}`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
+        "ai": "^6.0.177",
         "next": "^16.0.0",
+        "openai": "^6.37.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -23,6 +25,52 @@
         "eslint-config-next": "^16.0.0",
         "tsx": "^4.20.6",
         "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.112",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.112.tgz",
+      "integrity": "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1718,11 +1766,26 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2360,6 +2423,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2381,6 +2453,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.177",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.177.tgz",
+      "integrity": "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.112",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -3704,6 +3794,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4696,6 +4795,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5132,6 +5237,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
+      "integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -6489,7 +6615,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
       "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "logicpro-cheatsheets",
       "version": "1.0.0",
       "dependencies": {
+        "@ai-sdk/openai": "^3.0.63",
+        "@ai-sdk/react": "^3.0.179",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
@@ -44,6 +46,22 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.63",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.63.tgz",
+      "integrity": "sha512-4yY/m8a57MNNVoJCsXuNblKf6BO4yuAuLKRX4tzSNffBEBSp1FlcWdPE0Z4FkqUeS0AJhYSSqp0GIiA/cIcDNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/provider": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
@@ -71,6 +89,24 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.179",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.179.tgz",
+      "integrity": "sha512-wq3gqDrwi6QvwHQuVrTpjeUQI/LHZ5ysokWTIS1hOFw0UIIX8eVpri5iVvqQuq5CeQw/6bYXSI15SfMtZJixpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.27",
+        "ai": "6.0.177",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3092,6 +3128,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -6119,6 +6164,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6474,6 +6544,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "verify:content": "tsx scripts/verify-localized-content.ts"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.63",
+    "@ai-sdk/react": "^3.0.179",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "ai": "^6.0.177",
     "next": "^16.0.0",
+    "openai": "^6.37.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/public/content/content.json
+++ b/public/content/content.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "contentVersion": "20260510T145536Z",
-  "generatedAt": "2026-05-10T14:55:36.758Z",
+  "contentVersion": "20260510T152015Z",
+  "generatedAt": "2026-05-10T15:20:15.884Z",
   "minAppVersion": "1.0.0",
   "navItems": [
     {
@@ -11159,7 +11159,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq1_save_format_overview.png"
           },
           {
-            "number": 1,
+            "number": 2,
             "title": "Save Format Visual Examples",
             "concept": "Visual reference showing how Logic packages appear in Finder and what's contained inside.",
             "actions": [
@@ -11178,7 +11178,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq1_package_contents.png"
           },
           {
-            "number": 2,
+            "number": 3,
             "title": "I have limited hard drive space on my computer, is it okay to save files to a USB drive or network storage? What about plugins or samples?",
             "concept": "Storage location affects performance, reliability, and workflow speed. Understanding the hierarchy of storage types prevents corruption and frustration.",
             "actions": [
@@ -11202,7 +11202,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq2_storage_types.png"
           },
           {
-            "number": 2,
+            "number": 4,
             "title": "Storage Best Practices",
             "concept": "Practical workflows for managing projects across multiple storage locations.",
             "actions": [
@@ -11225,7 +11225,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq2_folder_organization.png"
           },
           {
-            "number": 3,
+            "number": 5,
             "title": "Should I change the buffer when mixing or recording?",
             "concept": "Buffer size balances input monitoring latency against CPU overhead. Recording needs low latency; mixing benefits from high efficiency.",
             "actions": [
@@ -11248,7 +11248,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq3_buffer_settings.png"
           },
           {
-            "number": 3,
+            "number": 6,
             "title": "Buffer Size in Practice",
             "concept": "Visual examples of buffer settings for different workflow scenarios.",
             "actions": [
@@ -11270,7 +11270,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq3_latency_comparison.png"
           },
           {
-            "number": 4,
+            "number": 7,
             "title": "Do I really need to buy plugins or can I use the stock plugins?",
             "concept": "Logic's included plugins are professional-grade tools. Third-party plugins offer different workflows, character, or specialized functions, but aren't required for quality results.",
             "actions": [
@@ -11292,7 +11292,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq4_stock_plugins_overview.png"
           },
           {
-            "number": 4,
+            "number": 8,
             "title": "Essential Stock Plugin Examples",
             "concept": "Visual tour of Logic's most powerful included plugins and their professional applications.",
             "actions": [
@@ -11315,7 +11315,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq4_vintage_compressors.png"
           },
           {
-            "number": 5,
+            "number": 9,
             "title": "I finished a song, how do I export it?",
             "concept": "Exporting (bouncing) renders your mix to a stereo file. Proper bounce settings preserve quality and ensure compatibility with mastering or distribution.",
             "actions": [
@@ -11338,7 +11338,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq5_bounce_dialog.png"
           },
           {
-            "number": 5,
+            "number": 10,
             "title": "Bounce Settings Explained",
             "concept": "Understanding each bounce option helps you choose the right settings for different delivery contexts.",
             "actions": [
@@ -11361,7 +11361,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq5_bounce_formats.png"
           },
           {
-            "number": 6,
+            "number": 11,
             "title": "I recorded a track but I barely see the waveform or the waveform is really large, what should I visually be looking for to know the levels are good?",
             "concept": "Waveform size indicates recording level. Healthy recordings show clear, visible waveforms without clipping. Understanding visual cues prevents problems in mixing.",
             "actions": [
@@ -11384,7 +11384,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq6_waveform_good_level.png"
           },
           {
-            "number": 6,
+            "number": 12,
             "title": "Waveform Problems and Solutions",
             "concept": "Visual examples of too-quiet, too-loud, and properly recorded waveforms with remediation strategies.",
             "actions": [
@@ -11406,7 +11406,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq6_waveform_comparison.png"
           },
           {
-            "number": 7,
+            "number": 13,
             "title": "Can I record several takes and choose parts of each?",
             "concept": "Logic's comp recording feature (take folders and comping) allows you to record multiple passes and assemble the best composite performance from them.",
             "actions": [
@@ -11428,7 +11428,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq7_take_folder_overview.png"
           },
           {
-            "number": 7,
+            "number": 14,
             "title": "Comping in Detail",
             "concept": "Visual walkthrough of comping techniques, crossfade adjustments, and advanced comp editing.",
             "actions": [
@@ -11450,7 +11450,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq7_comping_workflow.png"
           },
           {
-            "number": 8,
+            "number": 15,
             "title": "If I bounce a track do I lose the original?",
             "concept": "Bouncing in place renders a track to audio but doesn't delete the original. Understanding destructive vs non-destructive processes protects your work.",
             "actions": [
@@ -11473,7 +11473,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq8_bounce_in_place.png"
           },
           {
-            "number": 8,
+            "number": 16,
             "title": "Bounce in Place Options",
             "concept": "Detailed look at Bounce in Place settings and when to use each option.",
             "actions": [
@@ -11496,7 +11496,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq8_bounce_settings.png"
           },
           {
-            "number": 9,
+            "number": 17,
             "title": "Should I be mixing in mono or stereo?",
             "concept": "Mixing in mono helps ensure balance and frequency clarity before stereo imaging is applied. Both mono and stereo monitoring are essential at different stages.",
             "actions": [
@@ -11518,7 +11518,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq9_mono_stereo_comparison.png"
           },
           {
-            "number": 9,
+            "number": 18,
             "title": "Mono Compatibility in Practice",
             "concept": "Understanding phase correlation, stereo widening tools, and mono-safe mixing techniques.",
             "actions": [
@@ -11541,7 +11541,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq9_correlation_meter.png"
           },
           {
-            "number": 10,
+            "number": 19,
             "title": "How do I make the waveform bigger so I can see it?",
             "concept": "Logic offers multiple zoom controls for waveforms and track heights. Understanding these tools improves editing speed and visual clarity.",
             "actions": [
@@ -11564,7 +11564,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq10_track_zoom.png"
           },
           {
-            "number": 10,
+            "number": 20,
             "title": "Zoom Workflows for Editing",
             "concept": "Practical zoom workflows for common editing tasks: comping, cleaning up, arranging, and mixing.",
             "actions": [
@@ -11882,7 +11882,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step1_concept_diagram.png"
           },
           {
-            "number": 2,
+            "number": 12,
             "title": "Routing Methods in Logic Pro",
             "concept": "Logic offers multiple ways to create parallel paths: aux sends, track stacks, and manual routing via busses. Each method has strengths for different workflows.",
             "actions": [
@@ -11907,7 +11907,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step2_routing_sends.png"
           },
           {
-            "number": 3,
+            "number": 13,
             "title": "Parallel Compression on Drums",
             "concept": "Parallel compression (often called 'New York compression') adds density, sustain, and power to drums without squashing transients. It's the most popular parallel processing technique.",
             "actions": [
@@ -11933,7 +11933,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step3_drum_compression.png"
           },
           {
-            "number": 4,
+            "number": 14,
             "title": "Parallel Reverb for Depth Control",
             "concept": "Parallel reverb routing gives you precise control over wet/dry balance, allows independent processing of the reverb return, and prevents the reverb from smearing your dry signal.",
             "actions": [
@@ -11959,7 +11959,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step4_reverb_routing.png"
           },
           {
-            "number": 5,
+            "number": 15,
             "title": "Parallel Saturation and Harmonic Enhancement",
             "concept": "Parallel saturation adds warmth, grit, and harmonic richness without turning your mix into distorted mush. It's especially powerful on vocals, bass, and mix buses.",
             "actions": [
@@ -11985,7 +11985,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step5_saturation_chain.png"
           },
           {
-            "number": 6,
+            "number": 16,
             "title": "Balancing and Blending Parallel Chains",
             "concept": "The mix between your dry and parallel signals determines whether the technique enhances or destroys your sound. Developing an ear for the optimal blend is a core skill.",
             "actions": [
@@ -12010,7 +12010,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step6_blending_comparison.png"
           },
           {
-            "number": 7,
+            "number": 17,
             "title": "Advanced Applications: Multi-Band and Frequency-Specific Parallel Processing",
             "concept": "Parallel processing doesn't have to affect the entire frequency spectrum. Targeting specific frequency bands unlocks surgical control and creative possibilities.",
             "actions": [
@@ -12034,7 +12034,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step7_multiband_parallel.png"
           },
           {
-            "number": 8,
+            "number": 18,
             "title": "Common Mistakes and How to Avoid Them",
             "concept": "Parallel processing is powerful but easy to misuse. Understanding common pitfalls saves you time and improves your results.",
             "actions": [
@@ -12055,7 +12055,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step8_common_mistakes.png"
           },
           {
-            "number": 9,
+            "number": 19,
             "title": "Genre-Specific Parallel Processing Applications",
             "concept": "Different musical styles benefit from different parallel processing approaches. Tailoring your technique to your genre improves translation and impact.",
             "actions": [
@@ -12082,7 +12082,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step9_genre_applications.png"
           },
           {
-            "number": 10,
+            "number": 20,
             "title": "Putting It All Together: A Complete Parallel Processing Workflow",
             "concept": "Integrating parallel processing into your standard mixing workflow creates consistent, professional results without adding confusion or clutter.",
             "actions": [
@@ -12108,7 +12108,1142 @@
             "stepScreenshot": "/assets/training/parallel-busses/step6_blending_comparison.png"
           },
           {
-            "number": 12,
+            "number": 21,
+            "title": "Understanding the Stereo Field",
+            "concept": "The stereo field is the perceived horizontal space between left and right speakers where you position sounds in your mix.",
+            "actions": [
+              "Visualize the stereo field as a 180-degree arc from hard left (-64) through center (0) to hard right (+63).",
+              "Identify placement zones: center for foundational elements, 30-45° for rhythm parts, 60-90° for supporting elements.",
+              "Learn which instruments benefit most from stereo placement versus staying centered."
+            ],
+            "body": "Understanding the stereo field is fundamental to creating professional-sounding mixes with proper width, depth, and separation. The stereo field represents the horizontal space between your left and right speakers, and how you position sounds within this space dramatically affects your mix's clarity, power, and dimension.\n\nThink of the stereo field as a stage. Just as musicians occupy different positions on a physical stage, tracks in your mix occupy different positions in the stereo field. The center position is the most powerful and focused location—it's where the listener's attention naturally goes first. Foundational elements like kick drum, snare, bass guitar, and lead vocals almost always occupy the center because these are the elements that drive the song forward and need maximum impact and mono compatibility.\n\nThe mid-field positions (roughly 30-45 degrees left or right) are ideal for rhythm elements that support the foundation but don't need to be centered. Rhythm guitars, keyboard parts, and background vocals often sit in these zones, creating width while maintaining a cohesive relationship with the centered elements.\n\nThe wide positions (60-90 degrees) are reserved for atmospheric elements, pads, effects, stereo-widened instruments, and decorative parts that fill out the mix without competing for attention with core elements. These positions create the sense of space and immersion that makes mixes feel large and engaging.\n\nEffective stereo placement isn't just about spreading things out randomly—it's about creating balance, clarity, and intentional focus. A well-planned stereo field guides the listener's ear through the arrangement, prevents frequency masking by separating competing elements spatially, and creates a sense of space and professionalism that distinguishes amateur mixes from pro-level work.",
+            "symbolName": "speaker.wave.3.fill",
+            "visualTitle": "Stereo Field Basics",
+            "visualCaption": "Placement zones from center to wide positions.",
+            "settings": {
+              "Center Zone (0°)": "Kick, snare, bass, lead vocal",
+              "Inner Zone (30-45°)": "Rhythm guitars, keys, supporting vocals",
+              "Outer Zone (60-90°)": "Pads, effects, atmosphere, wide elements"
+            },
+            "proTip": "Visualize your stereo field on paper before mixing—sketch out where each element should sit to create intentional balance and avoid cluttered zones.",
+            "avoidThis": "Don't pan everything to extremes thinking more width is always better. An empty center leaves your mix weak and unfocused.",
+            "checkYourWork": "Your mix has clear focal points in the center, supporting elements create width without feeling disconnected, and the stereo field feels balanced and intentional.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step1_stereo_field_basics.png"
+          },
+          {
+            "number": 22,
+            "title": "Mastering Pan Controls",
+            "concept": "Logic Pro offers multiple panning modes that affect how stereo signals behave when panned off-center.",
+            "actions": [
+              "Right-click any pan knob to access pan mode options: Stereo Pan, Balance, and Binaural Pan.",
+              "Use Stereo Pan mode to preserve stereo width when panning stereo sources off-center.",
+              "Use Balance mode for simple left-right balance control of stereo signals.",
+              "Adjust the stereo spread using the white squares on the pan line in Stereo Pan mode."
+            ],
+            "body": "Logic Pro's pan controls are more sophisticated than simple left-right positioning. Understanding the different pan modes and how to use them effectively is crucial for professional stereo control.\n\nThe standard pan mode works perfectly for mono sources—turning the knob positions the sound anywhere from hard left to hard right. But what happens when you pan a stereo signal? This is where Logic's multiple pan modes become essential.\n\nStereo Pan mode (accessed by right-clicking the pan knob) preserves the stereo width of a signal when you pan it off-center. If you have a stereo synth pad panned to center, it maintains its full stereo width. When you pan it 30 degrees left using Stereo Pan mode, the entire stereo image moves left while keeping its width intact. This is ideal for moving stereo sources around the field without collapsing them to mono.\n\nIn Stereo Pan mode, you'll also notice two small white squares on the pan line. These control the stereo spread or width of the signal. Dragging them closer together narrows the stereo image, while pulling them apart widens it. This gives you precise control over both position and width from a single control.\n\nBalance mode, on the other hand, simply adjusts the relative level between left and right channels without preserving spatial characteristics. It's useful for quick fixes like correcting a slightly off-center stereo recording, but it doesn't maintain stereo imaging the way Stereo Pan does.\n\nBinaural Pan mode uses head-related transfer functions (HRTF) for 3D spatial positioning, primarily useful when mixing for headphones or creating immersive binaural content.\n\nKnowing which mode to use for each situation—Stereo Pan for moving and shaping stereo sources, standard pan for mono sources, and Balance for quick level corrections—gives you precise control over your stereo field.",
+            "symbolName": "dial.max",
+            "visualTitle": "Pan Control Modes",
+            "visualCaption": "Stereo Pan preserves width when panning.",
+            "settings": {
+              "Stereo Pan": "Preserves width, move stereo sources",
+              "Balance": "Simple L/R level control",
+              "Binaural Pan": "3D spatial positioning for headphones"
+            },
+            "proTip": "Set Stereo Pan as your default pan mode for stereo channels by right-clicking and selecting it once—Logic remembers your preference per channel type.",
+            "avoidThis": "Don't use Balance mode when you actually want to move a stereo image—it won't maintain the spatial characteristics properly.",
+            "checkYourWork": "Stereo sources maintain their width and character when panned, and you can precisely control both position and spread from the pan control.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step2_pan_controls.png"
+          },
+          {
+            "number": 23,
+            "title": "Understanding Pan Law",
+            "concept": "Pan law determines how much signal level decreases at the center position to maintain constant perceived loudness across the stereo field.",
+            "actions": [
+              "Check your pan law setting in Logic Pro > Settings > Audio > General.",
+              "Understand the three common pan law standards: -3dB, -4.5dB, and -6dB.",
+              "Choose -3dB for most modern music production to maintain consistent levels."
+            ],
+            "body": "Pan law is one of those invisible but critical aspects of mixing that affects how your levels translate across the stereo field. It determines how signal level changes as you pan sounds from left or right toward the center position.\n\nHere's the core problem pan law solves: when you pan a mono sound to hard left, all its energy goes to the left speaker. When you pan it to hard right, all energy goes to the right speaker. But when you pan it to center, that same sound comes equally from both speakers, which means your ears receive it from two sources instead of one. Without compensation, this makes centered sounds perceptually louder than panned sounds.\n\nPan law applies attenuation (volume reduction) at the center position to maintain consistent perceived loudness as sounds move across the stereo field. The number indicates how much attenuation is applied: -3dB pan law means center-panned signals are reduced by 3 decibels, -4.5dB means 4.5 decibels, and -6dB means 6 decibels.\n\nThe -3dB pan law is the modern standard and most common choice. It maintains fairly constant perceived loudness as you pan, which is what most contemporary producers expect. This setting works well for digital mixing and most musical styles.\n\nThe -4.5dB pan law is sometimes called the 'compromise' setting—it sits between -3dB and -6dB and was common in older analog consoles. Some engineers prefer it for its slightly different spatial character.\n\nThe -6dB pan law applies the most center attenuation. This creates a stronger sense of separation between panned elements, as centered sounds are quieter relative to hard-panned sounds. It's less common in modern production but can be useful for specific artistic choices.\n\nThe most important thing about pan law: be consistent within a project. Changing pan law mid-mix will alter your relative levels and balance. Choose a pan law setting that matches your workflow and stick with it across all your projects for consistent results and muscle memory.",
+            "symbolName": "ruler",
+            "visualTitle": "Pan Law Comparison",
+            "visualCaption": "Center attenuation maintains consistent loudness.",
+            "settings": {
+              "-3dB Pan Law": "Modern standard, constant perceived loudness",
+              "-4.5dB Pan Law": "Compromise, vintage console style",
+              "-6dB Pan Law": "Maximum center attenuation, strong separation"
+            },
+            "proTip": "If you're collaborating or sending projects to other engineers, note your pan law setting in project documentation so everyone works with the same standard.",
+            "avoidThis": "Don't change pan law settings mid-project—it will throw off your carefully balanced levels and relative positions.",
+            "checkYourWork": "Your levels remain perceptually consistent as you pan elements across the field, and your pan law matches industry standards you're working within.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step3_pan_law_comparison.png"
+          },
+          {
+            "number": 24,
+            "title": "Introduction to Direction Mixer",
+            "concept": "Logic Pro's Direction Mixer is a powerful stereo imaging plugin that provides precise control over stereo direction, spread, and width beyond standard pan controls.",
+            "actions": [
+              "Insert Direction Mixer on any stereo channel or bus.",
+              "Use the Direction knob to set the center position of the stereo image (0-180 degrees).",
+              "Adjust the Spread slider to control stereo width from mono (0%) to beyond normal width (200%).",
+              "Experiment with LR, Split, and M/S modes for different stereo processing approaches."
+            ],
+            "body": "The Direction Mixer is one of Logic Pro's most versatile stereo imaging tools, offering far more control than standard pan knobs. It's essentially a sophisticated stereo field manipulator that can position, widen, narrow, and even rotate stereo images with surgical precision.\n\nThe Direction knob controls the center position of your stereo image, ranging from 0 to 180 degrees. At 0 degrees, the image is centered normally. As you increase the value, the entire stereo image rotates. At 90 degrees, the image is rotated 90 degrees to the left. At 180 degrees, the left and right channels are completely swapped. This is incredibly useful for correcting stereo recordings that were tracked with reversed channels, or for creative stereo positioning that goes beyond simple panning.\n\nThe Spread slider controls the width of the stereo image. At 100%, the signal passes through at normal stereo width. At 0%, the signal is collapsed to mono. Values above 100% widen the stereo image beyond its original width, up to 200%. This widening can make sources feel more spacious and immersive, though extreme values may cause phase issues that affect mono compatibility.\n\nThe Direction Mixer operates in three modes: LR mode (standard left-right stereo processing), Split mode (frequency-dependent stereo control), and M/S mode (mid-side processing). Each mode offers different capabilities for shaping your stereo image.\n\nOne of the Direction Mixer's greatest strengths is its ability to process stereo width without introducing the harsh artifacts that simpler stereo widening plugins create. It uses sophisticated algorithms that maintain phase relationships while adjusting width, making it much safer for professional applications.\n\nCommon uses for Direction Mixer include: widening stereo keyboards and pads for larger-than-life presence, narrowing stereo samples that are too wide to sit well in a mix, correcting reversed-channel recordings, and creating frequency-dependent width processing where low frequencies stay narrow while high frequencies spread wide.",
+            "symbolName": "arrow.left.and.right.circle",
+            "visualTitle": "Direction Mixer Plugin",
+            "visualCaption": "Precise control over direction, spread, and width.",
+            "settings": {
+              "Direction": "0° = centered, 90° = rotated left, 180° = channels swapped",
+              "Spread": "0% = mono, 100% = normal, 200% = maximum width",
+              "Modes": "LR, Split (frequency-dependent), M/S (mid-side)"
+            },
+            "proTip": "Use Direction Mixer's Spread control between 0-100% to narrow overly-wide stereo samples so they fit better in dense mixes, rather than just lowering their volume.",
+            "avoidThis": "Don't push Spread above 150% on bass-heavy material—extreme widening at low frequencies causes phase cancellation and weak mono translation.",
+            "checkYourWork": "Your stereo sources have the exact width and position you intend, and they maintain clarity and power both in stereo and when checked in mono.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step5_spread_comparison.png"
+          },
+          {
+            "number": 25,
+            "title": "Controlling Stereo Spread",
+            "concept": "Stereo spread adjustments allow you to make elements narrower or wider to fit your mix, creating space, separation, and dimension.",
+            "actions": [
+              "Narrow overly-wide samples to create space in your mix (Spread 40-80%).",
+              "Widen pads and atmospheres for immersive depth (Spread 120-150%).",
+              "Keep low-frequency elements narrow (Spread 0-50%) to maintain mono compatibility.",
+              "Check phase correlation when widening to ensure mono translation."
+            ],
+            "body": "Controlling stereo spread is like adjusting the physical size of each element in your mix. Just as a drummer takes up more physical space on stage than a singer at a microphone, some elements in your mix should occupy more of the stereo field than others.\n\nNarrowing stereo spread is often just as important as widening. Many loops, samples, and virtual instruments come pre-processed with heavy stereo width that sounds impressive in solo but doesn't fit in a dense mix. These overly-wide elements push everything else out of the way and create a cluttered, unfocused stereo field. By narrowing their spread to 40-80%, you make room for other elements while still maintaining some stereo character.\n\nPads, string sections, ambient textures, and background vocals benefit from moderate to wide spread (120-150%). This creates depth and immersion, making your mix feel larger and more professional. Wide spread on these supporting elements helps them stay out of the way of centered lead elements while still contributing to the overall sonic picture.\n\nBass frequencies are particularly sensitive to stereo spread. Low-frequency information that's too wide causes phase cancellation issues, resulting in weak, thin bass on mono systems (smartphones, club systems, radio). Professional mixes keep bass guitar, kick drum, and sub-bass tightly centered or very narrow (Spread 0-50%). If you want stereo character on bass, apply it only to the midrange and high frequencies while keeping the fundamental frequencies centered.\n\nThe Direction Mixer's Spread control provides smooth, transparent width adjustment, but always verify your changes with mono and phase correlation checks. A correlation meter should show positive values (above zero) for the majority of your mix. Strong negative correlation indicates phase issues that will cause problems in mono playback.\n\nRemember that width creates separation through space, not necessarily through volume. Before reaching for the fader to make something louder, consider whether adjusting its stereo spread would help it fit better in the mix instead.",
+            "symbolName": "arrow.up.left.and.arrow.down.right",
+            "visualTitle": "Spread Comparison",
+            "visualCaption": "Narrow vs wide stereo spread examples.",
+            "settings": {
+              "Narrow (40-80%)": "Samples, loops, make space",
+              "Normal (90-110%)": "Most instruments, default",
+              "Wide (120-150%)": "Pads, atmosphere, depth",
+              "Bass (0-50%)": "Low frequencies, mono compatibility"
+            },
+            "proTip": "Use stereo spread adjustments before panning—sometimes narrowing a source makes it fit perfectly without needing to change its position.",
+            "avoidThis": "Don't widen everything hoping to create a bigger mix—you'll create phase chaos and a weak, thin sound in mono playback.",
+            "checkYourWork": "Your mix has intentional variation in width—some elements are focused and narrow, others are spacious and wide, creating dimension and clarity rather than uniform width.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step5_spread_comparison.png"
+          },
+          {
+            "number": 26,
+            "title": "Mid-Side Processing Fundamentals",
+            "concept": "Mid-side (M/S) processing splits stereo signals into Mid (center mono) and Side (stereo difference) channels, allowing independent processing of center versus wide content.",
+            "actions": [
+              "Understand that Mid contains everything that's identical in left and right channels (center content).",
+              "Understand that Side contains the differences between left and right channels (stereo width information).",
+              "Learn when to process Mid and Side independently for precise stereo control."
+            ],
+            "body": "Mid-side processing is one of the most powerful and versatile stereo techniques available in modern production. Unlike standard left-right stereo, which treats left and right channels as separate entities, mid-side processing reorganizes audio into two conceptually different channels: the Mid channel (center/mono information) and the Side channel (stereo width information).\n\nThe Mid channel contains everything that's identical in both the left and right channels. If you sum the left and right channels together, you get the Mid channel. This is where centered elements live—lead vocals, kick drums, snare drums, bass guitars, and anything else panned to the center. The Mid channel is essentially the mono version of your mix.\n\nThe Side channel contains the differences between the left and right channels. If you subtract the right channel from the left channel, you get the Side channel. This is where stereo width lives—panned instruments, stereo effects, room ambience, and anything that creates the sense of space and width in your mix.\n\nThe magic of mid-side processing is that you can apply completely different processing to the Mid and Side channels independently. Want to add presence to the lead vocal without affecting the wide stereo guitars? Process the Mid channel. Want to brighten the stereo atmosphere without making the centered bass brighter? Process the Side channel.\n\nMid-side thinking opens up countless mixing possibilities: you can EQ the center differently from the sides, compress the center to control lead vocals while leaving sides uncompressed for natural width, add saturation to the sides for excitement without affecting center clarity, or apply different reverb to center versus side content.\n\nLogic Pro's Channel EQ, Stereo Delay, Gain plugin, and several third-party processors offer built-in mid-side modes. The Direction Mixer also has an M/S mode specifically for processing mid-side signals. Understanding mid-side processing fundamentally changes how you think about stereo imaging, moving from simple left-right positioning to sophisticated center-versus-width control.",
+            "symbolName": "arrow.triangle.branch",
+            "visualTitle": "Mid-Side Signal Flow",
+            "visualCaption": "Stereo splits into Mid and Side channels.",
+            "settings": {
+              "Mid Channel": "Center mono content (L+R sum)",
+              "Side Channel": "Stereo width difference (L-R)",
+              "Processing": "Independent EQ, compression, effects per channel"
+            },
+            "proTip": "Use mid-side EQ to remove low frequencies from the Side channel only, keeping bass centered and mono-compatible while maintaining stereo width in higher frequencies.",
+            "avoidThis": "Don't confuse mid-side with left-right—they're different ways of organizing the same stereo information, not competing formats.",
+            "checkYourWork": "You understand that every stereo signal contains both Mid and Side information, and processing them independently gives you precise control over center versus width.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step6_midside_diagram.png"
+          },
+          {
+            "number": 27,
+            "title": "Applying Mid-Side EQ",
+            "concept": "Mid-side EQ allows you to shape the frequency content of centered elements independently from stereo-width elements.",
+            "actions": [
+              "Insert Logic's Channel EQ on a stereo channel or bus.",
+              "Click the M/S button to enable mid-side mode.",
+              "Apply different EQ curves to Mid and Side channels for precise frequency-spatial control."
+            ],
+            "body": "Mid-side EQ is where mid-side processing shows its incredible practical value. Logic Pro's Channel EQ includes a built-in M/S mode that splits the incoming stereo signal into Mid and Side channels, lets you apply completely different EQ curves to each, then recombines them back into standard left-right stereo output.\n\nCommon mid-side EQ applications include controlling bass frequencies independently from width. Since low frequencies should generally be centered for maximum power and mono compatibility, you can apply a high-pass filter to the Side channel (cutting low frequencies from the stereo width) while leaving the Mid channel full-range. This keeps your kick, snare, and bass powerful and centered while maintaining stereo width in the midrange and treble frequencies.\n\nAnother powerful technique is adding presence or air to the center without brightening the sides. If your lead vocal needs more high-frequency presence but your stereo guitars and pads are already bright enough, boost 8-12kHz on the Mid channel only. This brings the vocal forward without making the entire mix sound harsh or overly bright.\n\nYou can also create space by cutting midrange frequencies from the Side channel where your centered lead vocal sits, effectively carving out space in the stereo field for the vocal to occupy. This is like using EQ as a spatial tool rather than just a tonal tool.\n\nMid-side EQ is particularly useful on the master bus or mix bus for final stereo shaping. Gentle boosts in the Side channel high frequencies (10kHz and up) add air and space to the mix without making centered elements harsh. Cutting low-mids (200-500Hz) from the Side channel reduces muddiness in the stereo field while keeping center elements full and present.\n\nWhen using mid-side EQ, always check your changes in mono to ensure you're not creating phase issues or imbalances. Use gentle, musical EQ moves rather than extreme cuts or boosts, and always A/B your processing to verify it's actually improving the mix rather than just making it different.",
+            "symbolName": "slider.horizontal.2.square.on.square",
+            "visualTitle": "Mid-Side EQ Plugin",
+            "visualCaption": "Independent EQ curves for Mid and Side.",
+            "settings": {
+              "Side HPF": "80-120Hz to keep bass centered",
+              "Mid Presence": "3-5kHz boost for vocal clarity",
+              "Side Air": "10kHz+ gentle boost for space",
+              "Side Mud Cut": "200-500Hz reduction for clarity"
+            },
+            "proTip": "Use mid-side EQ on your drum bus to keep kick and snare powerful in the Mid while brightening cymbals and room in the Side channel.",
+            "avoidThis": "Don't apply extreme opposite EQ to Mid and Side—subtle differences create space and clarity; extreme differences create phase issues and strange tonality.",
+            "checkYourWork": "Your mix has clear separation between centered elements and stereo width, and EQ changes affect only the spatial zone you intended to process.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step7_midside_eq.png"
+          },
+          {
+            "number": 28,
+            "title": "The Haas Effect",
+            "concept": "The Haas effect (precedence effect) uses short delays (1-35ms) between left and right channels to create the perception of stereo width from a mono source.",
+            "actions": [
+              "Duplicate a mono track and pan copies hard left and right.",
+              "Apply a short delay (5-20ms) to one side only.",
+              "Verify mono compatibility—Haas effect signals often have phase cancellation in mono."
+            ],
+            "body": "The Haas effect, also called the precedence effect, is a psychoacoustic phenomenon where two identical sounds arriving within approximately 1-35 milliseconds are perceived as a single sound, but with directionality determined by whichever arrives first. This creates the illusion of stereo width from a mono source, making it sound wider and more spacious than simple panning alone.\n\nTo create a Haas effect, duplicate a mono signal onto two tracks or use a delay plugin in stereo mode. Pan one copy hard left and the other hard right. Apply a short delay (typically 10-20 milliseconds) to one side. The result is a wider, more spacious sound than the original mono source, without the need for recording the part twice.\n\nThe Haas effect works because your brain interprets the first-arriving sound as the 'real' source and the delayed sound as a spatial cue or reflection, creating the perception of width and space. The effect is most pronounced with delays between 10-20ms. Shorter delays (1-10ms) create subtle width; longer delays (20-35ms) create more obvious width but start to sound like distinct echoes rather than spatial enhancement.\n\nThe critical limitation of the Haas effect is mono compatibility. When left and right channels are summed to mono (as happens on many playback systems), the timing difference between the delayed and undelayed signals causes comb filtering—a series of phase cancellations that create a hollow, thin tone with missing frequencies. For this reason, Haas effect widening should be used sparingly and primarily on non-critical elements.\n\nBetter alternatives for most situations include: true double-tracking (recording the part twice), stereo recording with multiple microphones, or using less extreme Haas delays (under 10ms) where phase cancellation is less severe. The Haas effect works best on short transient sounds like percussion, effects, or brief vocal phrases where the timing difference adds space without long-term phase issues.\n\nUse the Haas effect as a creative special effect rather than a mixing foundation—save true stereo techniques for core elements that need to sound solid in all playback scenarios.",
+            "symbolName": "waveform.badge.plus",
+            "visualTitle": "Haas Effect Timing",
+            "visualCaption": "Short delay creates perceived width.",
+            "settings": {
+              "Subtle Width": "5-10ms delay",
+              "Moderate Width": "10-20ms delay",
+              "Strong Width": "20-35ms delay (mono issues likely)",
+              "Mono Compatibility": "Comb filtering occurs in mono playback"
+            },
+            "proTip": "If you must use Haas widening on important elements, keep the delay under 10ms and apply a slight low-cut to the delayed side to reduce low-frequency phase issues.",
+            "avoidThis": "Don't use Haas effect on bass, kick, snare, or lead vocals—these elements need solid mono translation, and Haas effect will weaken them significantly in mono playback.",
+            "checkYourWork": "Your Haas-widened elements sound spacious in stereo but check them in mono—if they sound thin, hollow, or weak, reduce the delay time or use a different widening technique.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step8_haas_effect.png"
+          },
+          {
+            "number": 29,
+            "title": "Double Tracking for Natural Width",
+            "concept": "True double tracking—recording the same part twice—creates authentic stereo width without the phase issues of artificial widening techniques.",
+            "actions": [
+              "Record the same part twice on separate tracks with natural performance variations.",
+              "Pan the two takes hard left and hard right or moderate left/right (30-50).",
+              "Accept that small timing and tonal differences create the magic—don't over-align or tune the takes."
+            ],
+            "body": "Double tracking is the gold standard for creating natural, phase-coherent stereo width. Unlike artificial widening techniques that manipulate a single recording, double tracking involves performing the same part twice, recording each performance on a separate track, and panning them left and right. The slight natural variations between the two performances create rich, organic width that translates perfectly to mono.\n\nClassic examples of double tracking include The Beatles' vocal techniques, where John Lennon would sing the same line twice and pan the takes to create a bigger vocal sound. In modern rock and metal production, rhythm guitars are almost always double-tracked (or quad-tracked with two pairs), creating the massive wall of guitars that defines these genres.\n\nThe key to effective double tracking is embracing the natural variations between takes. Small differences in timing, pitch, tone, and dynamics are what create the width and richness. If you over-edit the takes to align them perfectly, you lose the stereo effect and end up with something closer to a mono sound. The goal isn't perfection—it's controlled variation.\n\nFor vocals, double tracking works best on background vocals, harmonies, and gang vocals rather than lead vocals (where a single, centered performance usually sounds more intimate and direct). For guitars, double tracking is essential for rhythm parts and power chords, creating width and power. For acoustic instruments like acoustic guitar or ukulele, double tracking creates a fuller, more produced sound.\n\nThe panning choice affects the character: hard panning (full left and right) creates maximum width and separation, while moderate panning (30-50 degrees) creates a tighter, more cohesive sound that's still noticeably wider than mono. Experiment with different pan positions to find what serves the song and arrangement.\n\nDouble tracking is mono-safe because each performance is genuinely unique. When summed to mono, the takes combine into a single, reinforced sound rather than canceling out like phase-manipulated artificial widening. This makes double tracking the professional choice for any element that needs both stereo width and mono strength.",
+            "symbolName": "person.2.fill",
+            "visualTitle": "Double Tracking Setup",
+            "visualCaption": "Two genuine performances create natural width.",
+            "settings": {
+              "Hard Pan": "L -64, R +63 for maximum width",
+              "Moderate Pan": "L -35, R +35 for cohesion",
+              "Performance": "Natural variations, don't over-align",
+              "Mono Behavior": "Reinforces rather than cancels"
+            },
+            "proTip": "For ultra-wide guitars, record four takes: two panned hard left/right with slightly different tones or amp settings, creating massive stereo width with thickness and dimension.",
+            "avoidThis": "Don't use automatic doubling plugins thinking they'll match real double tracking—the phase relationships are different and won't translate as well to mono.",
+            "checkYourWork": "Your double-tracked elements sound wide and full in stereo, and when checked in mono, they sound reinforced and strong rather than thin or phased.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step9_double_tracking.png"
+          },
+          {
+            "number": 30,
+            "title": "Creative Stereo Delay",
+            "concept": "Logic Pro's Stereo Delay plugin creates rhythmic stereo width using independent left and right delay times, feedback, and crossfeed routing.",
+            "actions": [
+              "Insert Stereo Delay on a channel or send bus.",
+              "Set different delay times for left and right channels to create stereo movement.",
+              "Use crossfeed to send delayed signal from one channel to the other for complex patterns.",
+              "Sync delay times to your project tempo for musical, rhythmic delays."
+            ],
+            "body": "Logic Pro's Stereo Delay is far more than a simple echo effect—it's a sophisticated stereo imaging tool that can create width, movement, rhythm, and space in your mix. Unlike mono delays that create simple repetitions, stereo delays use independent timing for left and right channels to create spatial dimension and rhythmic complexity.\n\nThe fundamental approach is setting different delay times for the left and right channels. For example, a left delay of 1/8 note and a right delay of 1/16 note creates a ping-pong rhythm that bounces between speakers, adding movement and excitement. Tempo-synced delays (set in note values like 1/4, 1/8, 1/16) create musical rhythms that lock with your song, while millisecond-based delays create more subtle spatial effects.\n\nFeedback controls determine how many repetitions each delay produces. Low feedback (10-30%) creates short, subtle delays that add space without drawing attention. High feedback (50-80%) creates longer, more obvious delay tails that can become a rhythmic element in the arrangement. Be careful with feedback above 80%—it can create runaway delays that build infinitely.\n\nCrossfeed is one of Stereo Delay's most powerful features. It routes the delayed left signal to the right delay input (and vice versa), creating complex, interweaving delay patterns that bounce back and forth across the stereo field. This creates much more interesting and musical stereo movement than simple independent left/right delays.\n\nFiltering options (low-pass and high-pass filters) let you shape the tonal character of the delayed signal. A common technique is applying a low-pass filter to cut high frequencies from the delays, making them sit in the background and feel more like reflections or space rather than distinct echoes. This prevents delays from cluttering the mix and competing with dry signals.\n\nFor stereo width enhancement without obvious delays, use very short delay times (20-50ms) with low feedback and mix levels around 15-25%. This creates subtle spatial depth that makes sources feel larger and more three-dimensional without sounding like an obvious delay effect. For creative rhythmic effects, use tempo-synced note values with moderate to high feedback and experiment with crossfeed routing for complex patterns.",
+            "symbolName": "timer",
+            "visualTitle": "Stereo Delay Plugin",
+            "visualCaption": "Independent L/R timing creates movement.",
+            "settings": {
+              "Subtle Space": "20-50ms, 15-25% mix, low feedback",
+              "Rhythmic": "Tempo-synced note values, moderate feedback",
+              "Crossfeed": "50-70% for complex ping-pong patterns",
+              "Filtering": "Low-pass ~3-5kHz for background delays"
+            },
+            "proTip": "Use Stereo Delay on a send bus rather than as an insert so you can process multiple elements with the same delay space, creating cohesion and saving CPU.",
+            "avoidThis": "Don't use extreme feedback values (above 85%) unless you want infinite-building delays—they can quickly overpower your mix and become uncontrollable.",
+            "checkYourWork": "Your delays create stereo width and dimension without cluttering the mix, and rhythmic delays lock musically with your tempo and arrangement.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step10_stereo_delay.png"
+          },
+          {
+            "number": 31,
+            "title": "Monitoring Phase Correlation",
+            "concept": "Phase correlation meters show the phase relationship between left and right channels, helping you identify mono compatibility issues.",
+            "actions": [
+              "Use Logic's Multimeter plugin (Correlation Meter mode) or other phase correlation meters.",
+              "Understand the correlation scale: +1 (mono/in-phase), 0 (decorrelated stereo), -1 (out-of-phase).",
+              "Keep correlation mostly positive (above zero) for solid mono translation."
+            ],
+            "body": "Phase correlation monitoring is essential for ensuring your stereo tricks and widening techniques translate properly to mono playback. A correlation meter displays the phase relationship between left and right channels on a scale from +1 to -1, giving you visual feedback about mono compatibility.\n\nAt +1 (perfectly correlated), the left and right channels are identical—essentially a mono signal. This is what you see on centered, mono sources. It represents maximum mono compatibility but no stereo width.\n\nAt 0 (uncorrelated), the left and right channels contain completely independent information with no phase relationship. This represents natural stereo width created by panning, double tracking, or true stereo recording techniques. Uncorrelated signals maintain their full level when summed to mono.\n\nAt -1 (fully anti-correlated), the left and right channels are identical but inverted in polarity—one is a perfect opposite of the other. This creates maximum apparent stereo width but complete cancellation in mono playback. Negative correlation values indicate phase issues that will cause weak, thin, hollow sound in mono.\n\nProfessional mixes typically show correlation values that bounce between +0.5 and +1.0, occasionally dipping to 0 or slightly negative on specific elements with extreme width, but averaging well into positive territory. If your overall mix correlation spends significant time in negative values, you have phase issues that need attention.\n\nWidening plugins, Haas effect delays, mid-side processing with extreme Side boosts, and certain stereo effects can push correlation into negative territory. Use correlation monitoring while applying these techniques to catch problems before they become mix-ruining issues.\n\nWhen you see negative correlation, identify the source: bypass stereo effects one at a time until correlation improves, check for widening plugins with extreme settings, look for Haas delays that are too long or too loud, and verify that no channels have accidentally inverted polarity.\n\nMonitoring correlation is particularly important on the master bus, drum bus, and any bus where you're applying stereo widening or imaging effects. Catching phase issues during mixing is far easier than trying to fix them after mastering.",
+            "symbolName": "chart.line.uptrend.xyaxis",
+            "visualTitle": "Correlation Meter",
+            "visualCaption": "Monitor phase relationship for mono safety.",
+            "settings": {
+              "+1 (Mono)": "Identical L/R, perfect mono compatibility",
+              "0 (Decorrelated)": "Independent L/R, natural stereo width",
+              "-1 (Anti-phase)": "Inverted L/R, complete mono cancellation",
+              "Target Range": "Mostly +0.3 to +1.0, occasional 0 acceptable"
+            },
+            "proTip": "Set up a key command to toggle the Multimeter plugin's Correlation Meter mode so you can quickly check phase while mixing without opening plugin windows.",
+            "avoidThis": "Don't ignore negative correlation readings thinking 'nobody listens in mono anymore'—phones, Bluetooth speakers, club systems, and radio all sum to mono frequently.",
+            "checkYourWork": "Your correlation meter shows mostly positive values, averaging +0.5 or higher, with only brief excursions into neutral or slightly negative territory on specific wide elements.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step11_correlation_meter.png"
+          },
+          {
+            "number": 32,
+            "title": "Mono Compatibility Checks",
+            "concept": "Regular mono checking during mixing reveals balance issues, phase cancellation, and frequency masking that stereo playback can hide.",
+            "actions": [
+              "Set up a key command or control surface button to toggle mono playback instantly.",
+              "Check mono after every significant stereo adjustment, especially widening and panning changes.",
+              "Verify that essential elements (kick, snare, bass, lead vocal) remain strong in mono."
+            ],
+            "body": "Checking your mix in mono is one of the most revealing and important quality control steps in the mixing process. Mono playback exposes problems that stereo monitoring can mask, ensuring your mix translates to all playback systems including smartphones, mono Bluetooth speakers, club systems, broadcast, and any situation where stereo channels are summed to mono.\n\nMono checking reveals level balance issues. Elements that seem present and clear in stereo may completely disappear or become too loud in mono, indicating that their level balance depends on stereo positioning rather than actual volume. A well-balanced mix should maintain its core balance and hierarchy in mono, even if it sounds slightly less spacious or exciting.\n\nPhase cancellation becomes immediately obvious in mono. Stereo widening techniques, Haas delays, out-of-phase recordings, and certain stereo effects that sound impressive in stereo can cause elements to thin out, become hollow, or partially disappear in mono. If something sounds great in stereo but weak or strange in mono, you have a phase issue that needs correction.\n\nFrequency masking is easier to identify in mono. When panned elements collapse to center in mono playback, instruments that occupied different stereo positions now directly compete in the same space. If your mix becomes muddy, cluttered, or loses clarity in mono, it indicates that you've relied too heavily on stereo separation and need to create separation through EQ, level balance, or arrangement instead.\n\nProfessional engineers often build their initial rough balance in mono or toggle frequently between mono and stereo while mixing. This forces you to make separation through proper gain staging, EQ, and depth (reverb/delay) rather than relying solely on stereo positioning as a crutch.\n\nTo set up effective mono monitoring in Logic, assign a key command to 'Mono' under the Metering section, or use the mono button on your audio interface if available. Make toggling to mono a single keystroke or button press so you check frequently without breaking your workflow. Check mono especially after applying stereo widening, adjusting panning, adding delays or reverbs, and before finalizing any mix.",
+            "symbolName": "speaker.fill",
+            "visualTitle": "Mono Check Workflow",
+            "visualCaption": "Toggle mono to verify balance and compatibility.",
+            "settings": {
+              "Key Command": "Assign for instant mono toggle",
+              "Check Frequency": "After every stereo adjustment",
+              "Essential Elements": "Kick, snare, bass, lead vocal must stay strong",
+              "Problem Signs": "Disappearing elements, thin sound, muddy low-end"
+            },
+            "proTip": "Do a full playthrough of your mix in mono at least once before finalizing—you'll discover balance and clarity issues you'd never catch in stereo-only monitoring.",
+            "avoidThis": "Don't only check mono at the very end of mixing—by then, fixing phase and balance issues requires major changes. Check mono throughout the process.",
+            "checkYourWork": "Your mix maintains its core balance, energy, and clarity in mono, with only a natural reduction in spaciousness and width compared to stereo playback.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step12_mono_check.png"
+          },
+          {
+            "number": 33,
+            "title": "Frequency-Dependent Stereo: Split Mode",
+            "concept": "Direction Mixer's Split mode allows different stereo spread settings for separate frequency ranges, ideal for keeping bass centered while widening highs.",
+            "actions": [
+              "Insert Direction Mixer and select Split mode.",
+              "Set the crossover frequency (typically 120-250Hz) to separate low and high frequencies.",
+              "Apply narrow spread to low frequencies and wider spread to high frequencies."
+            ],
+            "body": "Frequency-dependent stereo processing is one of the most professional and sophisticated stereo techniques available. Direction Mixer's Split mode divides the incoming signal into two frequency bands using a crossover point you define, then applies independent stereo spread settings to each band. This solves one of mixing's most common problems: wanting stereo width in the highs while keeping bass frequencies centered and mono-compatible.\n\nThe typical application is setting the crossover between 100-250Hz (depending on the source material), applying narrow spread (0-30%) to the low band to keep bass centered and powerful, and applying wider spread (120-150%) to the high band to create space and dimension in the midrange and treble frequencies. This gives you the best of both worlds: solid, mono-compatible low end and spacious, immersive high end.\n\nSplit mode is particularly effective on full mixes, master bus processing, and instrument buses like a drum bus. On a drum bus, you can keep the kick and low-end of the snare centered and punchy while widening the cymbals, overheads, and room mics for a natural, spacious drum sound that still hits hard in mono.\n\nOn stereo synth pads and keyboards, Split mode lets you keep the fundamental frequencies (where the weight and power lives) focused in the center while spreading the harmonics and high-frequency shimmer wide across the stereo field. This prevents the pads from becoming too diffuse or weak while still creating atmospheric width.\n\nThe crossover frequency choice depends on the source material. For bass-heavy sources, set the crossover lower (80-120Hz) to keep only the deep sub-bass centered. For midrange-focused sources, set the crossover higher (200-300Hz) to keep more of the fundamental centered. Use your ears and a spectrum analyzer to identify where the source's energy is concentrated.\n\nSplit mode avoids the phase issues and mono compatibility problems of full-spectrum widening because the low frequencies—where phase issues are most problematic and where mono compatibility matters most—remain narrow or centered. Only the high frequencies, which are more phase-tolerant and less critical for mono translation, receive width processing.\n\nThis technique is standard in professional mastering and is increasingly common in mixing for creating modern, wide, immersive mixes that still sound powerful and focused on all playback systems.",
+            "symbolName": "waveform.path",
+            "visualTitle": "Split Mode Processing",
+            "visualCaption": "Independent width control per frequency band.",
+            "settings": {
+              "Crossover": "100-250Hz (adjust to source)",
+              "Low Band Spread": "0-30% (keep bass centered)",
+              "High Band Spread": "120-150% (widen mids/highs)",
+              "Applications": "Master bus, drum bus, synth pads, keyboards"
+            },
+            "proTip": "Use Split mode on your master bus with subtle settings (crossover 120Hz, low spread 10%, high spread 110%) for gentle, professional stereo enhancement that's completely mono-safe.",
+            "avoidThis": "Don't set the crossover too high (above 300Hz)—you'll narrow too much of the frequency spectrum and make your mix sound thin or disconnected.",
+            "checkYourWork": "Your low end feels powerful and centered in both stereo and mono, while your midrange and highs feel spacious and wide without phase issues.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step13_split_mode.png"
+          },
+          {
+            "number": 34,
+            "title": "Binaural Panner Basics",
+            "concept": "Logic's Binaural Panner uses head-related transfer functions (HRTF) to create 3D spatial positioning for headphone playback, placing sounds anywhere in 3D space.",
+            "actions": [
+              "Insert Binaural Panner on any mono or stereo channel.",
+              "Adjust azimuth (left-right position), elevation (up-down position), and distance.",
+              "Mix in headphones to experience the full 3D effect—Binaural Panner is optimized for headphone playback."
+            ],
+            "body": "Binaural panning represents the cutting edge of spatial audio for headphones. Unlike traditional stereo panning that creates a left-right soundstage between speakers, binaural processing uses head-related transfer functions (HRTF) to simulate how your ears perceive sound in three-dimensional space, creating the illusion of sounds appearing above, below, behind, and in front of you, not just left and right.\n\nThe technology works by modeling how sound waves interact with your head, ears, and upper body before reaching your eardrums. When a sound comes from behind you in real life, it sounds different than when it comes from in front because your head and outer ears (pinnae) filter and delay the sound waves differently depending on the source direction. Binaural panning recreates these cues digitally.\n\nLogic's Binaural Panner interface presents a sphere where you can position sounds anywhere in 3D space. Azimuth controls left-right positioning (traditional stereo panning), elevation controls up-down positioning, and distance controls how close or far the sound appears. Moving a sound source around the sphere in real-time creates incredibly realistic 3D motion effects.\n\nBinaural panning is primarily effective for headphone playback—the effect is much less pronounced on speakers because real speaker positioning creates its own spatial cues that can conflict with the binaural processing. This makes binaural panning ideal for podcast production, game audio, VR/AR content, meditation and relaxation tracks, and any content primarily consumed on headphones.\n\nFor music mixing, binaural panning can add unique spatial character to specific elements like background vocals (placed above or behind), effects and atmospheres (placed in unusual positions for surreal effects), or transitional elements (panned around the listener's head for dramatic movement). However, traditional stereo panning remains more practical for most music mixing since music is consumed on both speakers and headphones.\n\nWhen using Binaural Panner for music, apply it to supporting elements rather than core elements like lead vocals, kick, and bass. The 3D positioning can make sources feel disconnected from the main mix if overused. Subtle binaural positioning on pads, effects, and background elements creates immersive depth while keeping the foundation traditional and solid.\n\nAlways check how binaural-panned mixes translate to speakers—while they won't collapse completely, the 3D effect will be reduced, so verify your mix still works in both playback scenarios.",
+            "symbolName": "rotate.3d",
+            "visualTitle": "Binaural Panner Interface",
+            "visualCaption": "3D sound positioning for headphones.",
+            "settings": {
+              "Azimuth": "Left-right position (traditional stereo)",
+              "Elevation": "Up-down position (3D space)",
+              "Distance": "Near-far position (depth)",
+              "Best For": "Headphone-consumed content (podcasts, games, VR)"
+            },
+            "proTip": "For dramatic intro or transition effects, automate Binaural Panner position to move sounds around the listener's head in circular or spiral patterns—incredibly effective on headphones.",
+            "avoidThis": "Don't use Binaural Panner on every element thinking it will make everything 3D—overuse creates a disorienting mix that doesn't translate to speakers. Use selectively for special impact.",
+            "checkYourWork": "On headphones, your binaural-panned elements appear convincingly positioned in 3D space; on speakers, the mix still sounds coherent and balanced even if the 3D effect is reduced.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step14_binaural_panner.png"
+          },
+          {
+            "number": 35,
+            "title": "Stereo Width Zones by Instrument",
+            "concept": "Different instrument types benefit from different stereo width treatments based on their frequency content, role in the arrangement, and mono compatibility needs.",
+            "actions": [
+              "Keep foundational low-frequency instruments (kick, bass, sub-bass) centered or very narrow.",
+              "Use moderate width on rhythm instruments (guitars, keys) for balance.",
+              "Apply wide spread on atmospheric elements (pads, effects, backgrounds) for depth.",
+              "Verify each width decision in mono to ensure appropriate translation."
+            ],
+            "body": "Strategic stereo width assignment by instrument type is a hallmark of professional mixing. Not all instruments should be treated equally in terms of stereo spread—each instrument's frequency content, arrangement role, and importance determines its optimal width treatment.\n\nFoundational low-frequency instruments must stay centered or very narrow (spread 0-20%). This category includes kick drum, bass guitar, sub-bass synths, and the fundamental frequencies of snare drum. Low frequencies are non-directional in human hearing and contain the most energy, making them prone to phase issues if spread wide. Keeping them centered ensures maximum impact and perfect mono compatibility.\n\nRhythm and supporting instruments work well with moderate width (spread 80-120%). This includes rhythm electric guitars, acoustic guitars, piano, organ, synth chords, and supporting vocal harmonies. These elements benefit from some stereo character to create space and separation from centered elements, but don't need extreme width since they serve a supporting role rather than an atmospheric one.\n\nAtmospheric and background elements can take wide spread (spread 130-160%). This category includes string pads, synth pads, ambient textures, reverb returns, stereo delays, background 'ooh-aah' vocals, and sound effects. Wide spread pushes these elements to the edges of the stereo field, creating space and depth while keeping the center clear for lead elements.\n\nLead instruments and vocals typically stay centered (spread 90-110%) or just slightly wide. This includes lead vocals, lead guitar solos, lead synth melodies, and primary melodic instruments. These elements need maximum focus and impact, which comes from center positioning. Slight width (100-110%) can add polish without sacrificing focus.\n\nPercussion requires frequency-dependent treatment. Shakers, tambourines, and high-frequency percussion can be wide (spread 120-140%) to add excitement and movement. Hand drums, congas, and toms should be moderate (spread 80-100%) to maintain weight and focus. Kick and snare must stay centered as previously mentioned.\n\nThis width-by-instrument approach creates a natural depth hierarchy: bass and drums provide a solid, centered foundation; rhythm instruments create a supportive layer with moderate width; atmospheric elements fill the outer edges with spacious depth; and lead elements command attention from the powerful center position. This is the architecture of professional, three-dimensional mixes.",
+            "symbolName": "chart.bar.fill",
+            "visualTitle": "Width Zones by Instrument",
+            "visualCaption": "Strategic width assignment for clarity and depth.",
+            "settings": {
+              "Bass/Kick (0-20%)": "Centered foundation, mono-safe",
+              "Rhythm (80-120%)": "Moderate width, supporting role",
+              "Atmosphere (130-160%)": "Wide depth, background space",
+              "Lead (90-110%)": "Focused center, maximum impact",
+              "Percussion (varies)": "High perc wide, low perc moderate"
+            },
+            "proTip": "Draw a simple chart showing your stereo field from center to wide edges, then assign each instrument in your mix to a zone—this helps you visualize and balance width before mixing.",
+            "avoidThis": "Don't give everything the same width treatment thinking consistency is professional—intentional width variation creates the depth and dimension that separates amateur from pro mixes.",
+            "checkYourWork": "Your mix has clear width zones with centered foundation, moderate rhythm support, and wide atmospheric depth, creating three-dimensional space without cluttering or phase issues.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step15_width_zones.png"
+          },
+          {
+            "number": 36,
+            "title": "Identifying and Fixing Phase Cancellation",
+            "concept": "Phase cancellation occurs when left and right channels contain similar signals with opposite polarity, causing frequency loss and weak mono translation.",
+            "actions": [
+              "Use correlation meters to identify negative correlation (phase issues).",
+              "Check for inverted polarity on channels—flip polarity if one channel is accidentally inverted.",
+              "Reduce stereo widening effects, especially Haas delays and extreme spreading.",
+              "Replace artificial widening with true stereo techniques like double tracking."
+            ],
+            "body": "Phase cancellation is one of the most common and destructive problems in modern mixing, particularly as more producers use stereo widening plugins and effects without understanding the consequences. When similar audio signals with opposite polarity combine, they cancel each other out, creating frequency gaps, thin sound, and weak mono translation that can ruin an otherwise great mix.\n\nPhase cancellation happens in several common scenarios: Haas effect delays where the delayed signal's polarity is inverted or partially inverted; stereo widening plugins that use polarity inversion or mid-side manipulation with extreme settings; accidentally inverted polarity on one channel of a stereo recording; close-miked instruments where phase relationships between multiple mics cause cancellation; and mid-side processing with extreme Side boosts that create unnaturally wide, out-of-phase signals.\n\nThe symptoms of phase cancellation include: thin, hollow, or 'phasey' tone; weak low end even though the source has bass content; elements that disappear or become much quieter in mono playback; correlation meters showing negative values; and frequency analyzer showing obvious gaps or notches in the spectrum.\n\nTo fix phase cancellation, first identify the problem source. Solo individual channels or buses while watching a correlation meter—when correlation goes negative, you've found the problem. Check for inverted polarity by selecting the channel and looking for a polarity flip button (Ø symbol). If one channel of a stereo pair has inverted polarity, flip it back to normal.\n\nReduce or bypass stereo widening effects one at a time to see which is causing phase issues. Haas delays longer than 15ms are particularly problematic—shorten the delay time or reduce the wet/dry mix. Stereo widening plugins with 'width' parameters above 150% often cause phase issues—reduce the width to more moderate settings.\n\nFor stereo recordings with inherent phase issues, try inverting the polarity of one channel to see if the sound becomes fuller and stronger. This is common with drum overheads, stereo guitar mics, and room mics where mic placement causes phase interference.\n\nThe best solution is prevention: use true stereo techniques like double tracking instead of artificial widening; keep Haas delays under 10ms or avoid them on important elements; monitor correlation throughout mixing; and always verify your stereo tricks in mono playback before committing to them.",
+            "symbolName": "exclamationmark.triangle.fill",
+            "visualTitle": "Phase Cancellation Warning",
+            "visualCaption": "Identifying and fixing phase issues.",
+            "settings": {
+              "Correlation": "Negative values indicate phase problems",
+              "Polarity Check": "Verify no channels have inverted polarity",
+              "Widening Reduction": "Lower spread/width settings on plugins",
+              "Haas Limit": "Keep delays under 10ms for mono-safe width"
+            },
+            "proTip": "Use the 'Check Phase' technique: if making something wider makes it sound bigger in stereo but weaker in mono, you've created phase issues—back off the widening.",
+            "avoidThis": "Don't ignore phase correlation meters or skip mono checks—these are your early warning system for phase problems that will ruin your mix translation.",
+            "checkYourWork": "Your correlation meter shows mostly positive values, your mix sounds full and strong in both stereo and mono, and widened elements maintain their body and impact in mono playback.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step16_phase_cancellation.png"
+          },
+          {
+            "number": 37,
+            "title": "Stereo Imaging Plugin Chain",
+            "concept": "Proper signal flow order for stereo processing plugins affects the final stereo image quality—position, then width, then spatial effects.",
+            "actions": [
+              "Position first: Use Direction Mixer or pan controls to set the center position.",
+              "Width second: Adjust stereo spread with Direction Mixer Spread control.",
+              "Spatial effects last: Add stereo delays, reverbs, and modulation effects after positioning and width."
+            ],
+            "body": "The order in which you apply stereo processing significantly affects the final stereo image quality and character. Understanding proper signal flow for stereo imaging plugins ensures clean, professional results without unwanted artifacts or processing conflicts.\n\nThe general rule is: position first, then width, then spatial effects. This order mirrors how you'd approach stereo imaging conceptually—decide where an element sits in the field, then how much space it occupies, then what kind of environmental character it has.\n\nPosition (Direction Mixer Direction knob, or pan controls) determines the center point of your stereo image. This is the foundation—where in the left-right field does this element live? Process this first because width and spatial effects build on this placement. If you widen a sound first then rotate it, you may get unexpected results as the widening algorithm wasn't designed to operate on rotated signals.\n\nWidth (Direction Mixer Spread control, stereo imagers) determines how much of the stereo field the element occupies. Apply width processing after positioning but before spatial effects. Width affects the direct sound character and should be established before adding environmental effects that further interact with the stereo image.\n\nSpatial effects (reverb, delay, chorus, flanger) add depth, space, and movement. These process the already-positioned, already-widened signal to place it in an environment or create modulation. Spatial effects often generate their own stereo image, which should build on your intentional positioning and width decisions rather than competing with them.\n\nEQ and dynamics processing (compression, saturation) typically come before stereo imaging in the signal chain. You want to shape the tone and dynamics of the source before manipulating its stereo characteristics, as EQ and compression can subtly affect phase relationships that stereo processing then builds upon.\n\nA typical professional stereo imaging signal chain looks like: Input → EQ → Compression → Direction Mixer (position + width) → Stereo Delay → Reverb → Output. This creates tonal balance, dynamic control, intentional stereo imaging, and then environmental character in that logical order.\n\nFor mid-side processing, the order is slightly different: Input → EQ (possibly mid-side) → Compression → Mid-Side Processor → Spatial Effects → Output, since mid-side processing affects both position and width simultaneously.",
+            "symbolName": "arrow.right.to.line.alt",
+            "visualTitle": "Stereo Plugin Chain",
+            "visualCaption": "Signal flow: position, width, spatial effects.",
+            "settings": {
+              "Position (First)": "Direction Mixer Direction, pan controls",
+              "Width (Second)": "Direction Mixer Spread, imagers",
+              "Spatial (Third)": "Reverb, delay, modulation",
+              "Before All": "EQ, compression, dynamics"
+            },
+            "proTip": "Save your go-to stereo imaging chain as a channel strip preset so you can instantly recall it on any channel that needs professional stereo treatment.",
+            "avoidThis": "Don't randomly insert stereo processors in any order—processing order matters for stereo imaging, and wrong order creates unpredictable artifacts.",
+            "checkYourWork": "Your stereo-processed elements have clear, intentional positioning, appropriate width, and cohesive spatial character without conflicts or artifacts between processors.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step17_stereo_chain.png"
+          },
+          {
+            "number": 38,
+            "title": "Common Stereo Mistakes",
+            "concept": "Avoiding common stereo imaging mistakes prevents weak mixes, phase issues, and translation problems across different playback systems.",
+            "actions": [
+              "Don't widen bass frequencies—keep low-end centered or narrow.",
+              "Don't pan everything to extremes—maintain center content for focus.",
+              "Don't use excessive Haas delays—they cause severe mono cancellation.",
+              "Don't skip mono checking—catch phase issues before finalizing."
+            ],
+            "body": "Even experienced mixers fall into common stereo imaging traps that compromise mix quality, mono compatibility, and professional translation. Understanding these mistakes helps you avoid them and create mixes that sound great on all playback systems.\n\nMistake #1: Over-widening bass frequencies. Bass frequencies below 100Hz should almost never be widened. They're non-directional in human hearing, contain massive energy, and cause severe phase cancellation in mono when spread wide. Wide bass sounds impressive on high-end studio monitors but disappears on phones, Bluetooth speakers, and club systems. Keep kick, bass guitar, and sub-bass centered or very narrow (spread 0-20%). If you want stereo character on bass instruments, apply it only to midrange and high harmonics using frequency-dependent processing (Split mode).\n\nMistake #2: Panning everything to extremes. Beginners often hard-pan everything left or right thinking maximum separation creates the best mix, leaving the center empty except for vocals. This creates a weak, hollow, disconnected mix with no focal point. Professional mixes maintain strong center content (kick, snare, bass, lead vocal, lead instruments) with moderate panning for supporting elements and wide positioning only for atmospheric parts.\n\nMistake #3: Excessive Haas delays. The Haas effect creates apparent width but at the cost of severe phase cancellation in mono. Delays longer than 15-20ms create obvious comb filtering when summed to mono, making sources sound thin, hollow, and weak. If you must use Haas effect widening, keep delays under 10ms and apply it only to non-essential elements, never to bass, drums, or lead vocals.\n\nMistake #4: No mono checking. Many producers mix entirely in stereo, never checking mono compatibility until mastering or worse, after release. Mono playback is still extremely common (phones, Bluetooth speakers, club systems, broadcast), and phase issues that sound fine in stereo destroy mixes in mono. Toggle to mono frequently throughout mixing, especially after any stereo widening or positioning changes.\n\nMistake #5: Artificial widening instead of true stereo techniques. Widening plugins are tempting shortcuts, but they manipulate phase relationships in ways that often cause mono issues. True stereo techniques like double tracking, stereo recording with multiple mics, and natural panning create authentic width that translates perfectly to mono. Use artificial widening sparingly on non-critical elements only.\n\nMistake #6: Ignoring correlation meters. Negative correlation values indicate out-of-phase signals that will cause problems, but many producers don't monitor correlation. Use a correlation meter on your master bus and check it regularly—mostly positive values (+0.3 to +1.0) indicate healthy stereo that will translate well.\n\nMistake #7: Extreme mid-side processing. Mid-side EQ and dynamics are powerful, but extreme settings (massive Side boosts, Mid scooping) create unnatural, phase-problematic results. Use mid-side processing with restraint and musicality, not as an extreme special effect.\n\nAvoiding these mistakes ensures your stereo imaging enhances your mix rather than compromising it, creating professional translations across all playback systems.",
+            "symbolName": "xmark.circle.fill",
+            "visualTitle": "Common Stereo Mistakes",
+            "visualCaption": "Avoid these critical stereo imaging errors.",
+            "settings": {
+              "Wide Bass": "Never—keep bass centered or narrow",
+              "Extreme Panning": "Avoid—maintain strong center content",
+              "Long Haas Delays": "Risky—keep under 10ms or avoid",
+              "No Mono Check": "Critical mistake—check mono frequently",
+              "Artificial Widening": "Sparingly—prefer true stereo techniques",
+              "Negative Correlation": "Problem—keep correlation positive",
+              "Extreme M/S": "Careful—use moderate, musical settings"
+            },
+            "proTip": "Create a pre-mastering checklist that includes mono playback, correlation meter check, and bass frequency width verification—catch stereo mistakes before they become release problems.",
+            "avoidThis": "Don't chase 'the widest mix possible' as a goal—chase clarity, balance, and solid translation instead. Width is a tool for those goals, not the goal itself.",
+            "checkYourWork": "Your bass is centered and powerful, your stereo field is balanced with strong center content, your correlation stays mostly positive, and your mix sounds great in both mono and stereo playback.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step18_common_mistakes.png"
+          },
+          {
+            "number": 39,
+            "title": "Professional Stereo Workflow",
+            "concept": "A systematic stereo imaging workflow ensures consistent, professional results and prevents costly mixing mistakes.",
+            "actions": [
+              "Step 1: Build initial balance in mono to establish solid foundation.",
+              "Step 2: Add panning for spatial separation while maintaining center strength.",
+              "Step 3: Apply width enhancements to supporting and atmospheric elements.",
+              "Step 4: Check phase correlation and verify mono compatibility.",
+              "Step 5: Make final stereo adjustments based on translation tests.",
+              "Step 6: Document stereo decisions for recall and consistency."
+            ],
+            "body": "Professional mixers follow systematic workflows that ensure consistent results and catch problems before they become disasters. A structured stereo imaging workflow prevents the common pitfalls of random, reactive mixing and creates mixes that translate beautifully to all playback systems.\n\nStep 1: Build initial balance in mono. Start your mix with the master bus switched to mono, or build your rough balance before adding any stereo processing. This forces you to create separation through volume, EQ, and depth (reverb) rather than relying on stereo positioning as a crutch. Elements that work in mono will always work in stereo, but the reverse isn't true.\n\nStep 2: Add panning for spatial separation. Once your mono balance is solid, switch to stereo and add panning to create spatial separation. Keep foundational elements (kick, snare, bass, lead vocal) centered. Pan rhythm and supporting elements to moderate positions (30-50 degrees). Reserve wide positions (60-90 degrees) for atmospheric and background elements. Check mono after major panning changes to verify nothing disappeared.\n\nStep 3: Apply width enhancements to supporting and atmospheric elements. With panning established, add stereo width processing to elements that benefit from it: widen pads and atmospheres with Direction Mixer or mid-side processing, add stereo delays for spatial depth, narrow overly-wide samples to create space in the mix. Keep bass frequencies centered using frequency-dependent processing (Split mode) when widening full-spectrum sources.\n\nStep 4: Check phase correlation and verify mono compatibility. Open a correlation meter on your master bus and check that your mix shows mostly positive correlation (+0.3 to +1.0), with only brief excursions to neutral or slightly negative. Toggle to mono and listen critically—all essential elements should remain strong and present, the balance should be maintained, and nothing should sound thin, hollow, or weird. If problems appear, identify and fix the source.\n\nStep 5: Make final stereo adjustments based on translation tests. Listen to your mix on multiple playback systems: studio monitors, headphones, phone speakers, car stereo, Bluetooth speakers. Identify any translation issues and make corrective stereo adjustments. Does the bass hold up on small speakers (indicating good mono compatibility)? Do wide elements feel cohesive or disconnected? Does the mix maintain its balance across systems?\n\nStep 6: Document stereo decisions for recall and consistency. Note your stereo imaging choices in project documentation: pan positions for key elements, width settings, mid-side processing approaches, and any special stereo techniques used. This ensures you can recall your approach when revisiting the project, maintain consistency across songs in an album or EP, and learn from what worked or didn't work.\n\nThis workflow creates professional stereo imaging systematically, catching problems early when they're easy to fix, and ensuring your mix translates well to all playback scenarios.",
+            "symbolName": "checklist",
+            "visualTitle": "Professional Stereo Workflow",
+            "visualCaption": "Systematic approach ensures consistent results.",
+            "settings": {
+              "Step 1": "Build in mono—solid foundation",
+              "Step 2": "Add panning—spatial separation",
+              "Step 3": "Enhance width—atmosphere and depth",
+              "Step 4": "Check phase—correlation and mono",
+              "Step 5": "Test translation—multiple systems",
+              "Step 6": "Document—recall and consistency"
+            },
+            "proTip": "Create a custom project template with your stereo workflow built in: mono reference channels, correlation meters pre-routed, key commands assigned, and documentation notes ready to fill in.",
+            "avoidThis": "Don't mix reactively, randomly adding stereo effects and widening whenever something doesn't sound good enough—follow a systematic workflow for predictable, professional results.",
+            "checkYourWork": "You've followed each workflow step, documented your stereo decisions, verified mono compatibility and phase correlation, and tested translation on multiple playback systems before finalizing your mix.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step19_workflow.png"
+          },
+          {
+            "number": 40,
+            "title": "Stereo Automation for Dynamic Width",
+            "concept": "Automating stereo width throughout your mix creates dynamic, engaging productions with width that changes intentionally for musical impact.",
+            "actions": [
+              "Identify section-based width changes: narrow verses for intimacy, wide choruses for impact.",
+              "Automate Direction Mixer Spread for smooth width transitions.",
+              "Create build-ups by gradually widening from narrow to maximum width.",
+              "Use automation for special effects like width ducking or width swells."
+            ],
+            "body": "Static stereo width throughout an entire song is a missed opportunity for creating dynamic, engaging, professional productions. Automating stereo width creates intentional contrast between sections, builds energy for choruses and drops, and adds movement and excitement that static mixing can't achieve.\n\nSection-based width automation is the foundation technique. Verses often benefit from slightly narrower width (spread 80-100%) to create intimacy and focus on lyrics and melody. Pre-choruses can gradually widen to build anticipation. Choruses explode with wider settings (spread 120-140%) to create impact, energy, and release. Bridges might return to narrow or moderate width to create contrast and reset energy before the final chorus.\n\nDirection Mixer Spread is ideal for automation because it smoothly adjusts stereo width without clicks or artifacts. Draw automation curves that gradually widen from verse to chorus over 2-4 bars, creating a natural build. Avoid instant width jumps (which sound unnatural and jarring) in favor of smooth transitions that the listener feels subconsciously rather than noticing overtly.\n\nBuild-ups use width automation for dramatic effect. Start a build section at narrow width (spread 40-60%), gradually increase to normal width (100%) through the build, then explode to maximum width (140-150%) on the drop or chorus downbeat. Combined with volume, filter, and reverb automation, width automation intensifies the build and maximizes impact on the drop.\n\nSpecial effects include: width ducking (briefly narrowing width on kick hits for pumping effect), width swells (sweeping from narrow to wide and back on transitions or fills), call-and-response width (alternating between narrow and wide on different phrases), and breakdown width reduction (collapsing to near-mono in breakdowns for maximum contrast when full width returns).\n\nOn background vocals and harmonies, automate width to follow the lead vocal's intensity—narrow during intimate lead vocal phrases, widening when the lead vocal gets powerful to create supportive bigness. On synth pads and atmospheres, automate width to create movement and interest without changing pitch or filter settings.\n\nAlways check width automation moves in mono to ensure no phase issues occur at any automation point. Some width settings may sound great at one value but cause problems at another, so test the full range. Use correlation meters while playing back automated sections to verify you're not creating phase problems at peak width values.\n\nWidth automation is a professional technique that separates amateur static mixes from dynamic, engaging professional productions. It's subtle enough that listeners don't consciously notice it, but powerful enough that they feel the energy, contrast, and movement it creates.",
+            "symbolName": "waveform.path.badge.plus",
+            "visualTitle": "Stereo Width Automation",
+            "visualCaption": "Dynamic width creates energy and contrast.",
+            "settings": {
+              "Verse": "Narrow (80-100%) for intimacy",
+              "Pre-Chorus": "Gradual widen to build anticipation",
+              "Chorus": "Wide (120-140%) for impact",
+              "Build-Up": "40% → 100% → 150% on drop",
+              "Breakdown": "Near-mono for contrast",
+              "Transition Length": "2-4 bars for smooth, natural feel"
+            },
+            "proTip": "Automate width on your drum bus to make choruses feel bigger—narrow slightly in verses (90%), widen in choruses (110%)—subtle but effective for creating section contrast.",
+            "avoidThis": "Don't automate width on bass frequencies or core elements—width automation works best on pads, atmospheres, background vocals, and supporting elements, not foundation elements.",
+            "checkYourWork": "Your width automation creates noticeable energy and contrast between sections, transitions smoothly without artifacts, and maintains mono compatibility at all automation points.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step22_stereo_automation.png"
+          },
+          {
+            "number": 41,
+            "title": "Understanding Sidechaining Fundamentals",
+            "concept": "Sidechaining uses one audio signal to control the behavior of a processor on another track, creating dynamic space and movement in your mix.",
+            "actions": [
+              "Learn the signal flow: source track (trigger) controls processor on target track (affected).",
+              "Understand the difference between transparent mixing sidechaining and creative effect sidechaining.",
+              "Identify which Logic Pro plugins support sidechain input."
+            ],
+            "body": "Sidechaining is a routing technique where one audio signal—the 'trigger' or 'key' signal—controls a processor on a different track. The most common application is sidechain compression, but Logic Pro supports sidechaining with compressors, gates, auto-filters, and several synthesizers.\n\nThe fundamental concept is this: instead of a processor responding to the audio on its own track, it responds to audio from somewhere else. When a kick drum plays, sidechain compression on the bass track 'hears' that kick and compresses the bass at that moment, creating space for the kick to cut through.\n\nThere are two broad philosophical approaches to sidechaining:\n\n**Transparent Sidechaining (Mixing):** The goal is clarity and space without obvious artifacts. You want elements to coexist without frequency masking, but you don't want listeners to consciously notice the ducking. This is common in professional pop, rock, hip-hop, and film mixing. Settings are gentle: low ratios (2:1 to 4:1), moderate attack, release timed to musical phrases.\n\n**Creative Sidechaining (Production):** The ducking effect is deliberate and obvious, often rhythmic and exaggerated. This is the 'pumping' sound in EDM, French house, and modern pop. Settings are aggressive: high ratios (8:1 to ∞:1), fast attack, release synchronized to tempo. The effect becomes part of the arrangement's character.\n\nIn Logic Pro, the following plugins support sidechain input:\n- Compressor (all types including Vintage models)\n- Noise Gate\n- Expander\n- Auto Filter\n- Enveloper\n- EVOC 20 TrackOscillator\n- ES2, Sculpture, and EVOC 20 PolySynth (for synthesis applications)\n\nThird-party plugins like FabFilter Pro-C 2, FabFilter Pro-Q 3 (dynamic EQ), Trackspacer, Soothe 2, and Waves C1 also offer advanced sidechain features, though Logic's stock tools are fully capable for most tasks.\n\nThe sidechaining workflow always follows this pattern:\n1. Place the processor (compressor, gate, etc.) on the track you want to affect (target).\n2. In the processor's interface, locate the Sidechain or 'Side Chain' menu (usually top-right corner).\n3. Select the track or bus you want to use as the trigger source.\n4. Adjust the processor's parameters to achieve your desired response.\n\nSidechaining is one of the most powerful tools in modern mixing and production. It solves frequency masking problems, creates space for vocals and lead elements, automates dynamic changes that would be tedious to write manually, and generates creative rhythmic movement. Understanding when and how to apply it separates amateur mixes from professional ones.",
+            "symbolName": "point.3.filled.connected.trianglepath.dotted",
+            "visualTitle": "Sidechain Signal Flow",
+            "visualCaption": "Source signal controls target processor.",
+            "settings": {
+              "Transparent Settings": "Ratio 2:1-4:1, moderate attack/release",
+              "Creative Settings": "Ratio 8:1+, fast attack, tempo-synced release",
+              "Supported Plugins": "Compressor, Gate, Auto Filter, and more"
+            },
+            "proTip": "When learning sidechaining, start with obvious, exaggerated settings so you can clearly hear what's happening. Once you understand the behavior, dial back the intensity for transparent mixing results.",
+            "avoidThis": "Don't apply sidechaining to every track by default. Use it to solve specific problems or create intentional effects—overuse creates an unstable, pumping mix where nothing feels anchored.",
+            "checkYourWork": "You can explain the signal flow of sidechaining and identify which track is the trigger and which is the target.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step1_sidechain_concept.png"
+          },
+          {
+            "number": 42,
+            "title": "Classic Application: Kick-Bass Ducking",
+            "concept": "Sidechaining bass to kick drum creates low-end clarity by temporarily reducing bass volume when the kick hits, preventing frequency masking in the 40-80Hz range.",
+            "actions": [
+              "Place a compressor on your bass track.",
+              "Set the compressor's sidechain input to your kick drum track.",
+              "Use fast attack (0.1-5ms), moderate ratio (3:1-6:1), and release timed to groove (50-150ms).",
+              "Adjust threshold until you see 3-6dB of gain reduction on each kick hit."
+            ],
+            "body": "The kick drum and bass guitar (or synth bass) both occupy the critical low-frequency range between 40Hz and 80Hz. When both play simultaneously, they compete for the same physical space in speakers and headphones, creating a muddy, undefined low end. This is a fundamental physics problem: a speaker cone can only move in one direction at a time, so overlapping low-frequency signals either reinforce (if perfectly in phase) or cancel each other (if out of phase). More commonly, they simply blur together into indistinct rumble.\n\nSidechain compression solves this by briefly reducing the bass level whenever the kick drum plays, giving the low-end frequency spectrum to the kick during its transient and fundamental tone. As the kick's energy fades, the bass swells back up to fill the space. When done well, the listener doesn't consciously hear ducking—they just hear a tight, punchy low end where kick and bass feel locked together.\n\nHere's the step-by-step setup:\n\n1. Insert Logic's Compressor plugin on your bass track (audio or software instrument).\n\n2. In the compressor interface, locate the 'Side Chain' drop-down menu in the top-right section. Click it and select your kick drum track from the list. If your kick is bussed or part of a drum group, you can select that bus instead.\n\n3. Set the compressor's Attack to 0.1ms to 5ms. You want the compression to engage the instant the kick transient arrives. Fast attack ensures the bass ducks immediately, preventing overlap.\n\n4. Set the Ratio to 3:1 or 4:1 for transparent mixing, or 6:1 to 8:1 if you want more obvious ducking (common in EDM or hip-hop). Higher ratios mean more aggressive volume reduction.\n\n5. Set the Release time based on your track's tempo and groove. For fast dance music (120-128 BPM), try 50ms to 80ms. For slower hip-hop or R&B (80-100 BPM), try 100ms to 150ms. The goal is for the bass to swell back to full volume just as the next kick is about to hit, creating a rhythmic pumping that grooves with the track.\n\n6. Adjust the Threshold until you see the gain-reduction meter showing 3dB to 6dB of reduction on each kick hit. Too much reduction (10dB+) makes the ducking obvious and can kill the bass's energy. Too little (1dB or less) may not solve the masking problem.\n\n7. Leave the Knee at its default (moderate/soft) for most applications. Hard knee creates more obvious compression; soft knee is smoother.\n\n8. Do not add makeup gain on the bass compressor—you're intentionally creating volume reduction here, not trying to make the bass louder overall.\n\n9. Check your mix in mono and at low volume. The kick should feel punchy and defined, and the bass should feel rhythmic and present without fighting the kick.\n\nThis technique is a foundational skill in modern production. It's used on virtually every professional EDM, pop, and hip-hop track. Even rock and metal mixes benefit from subtle kick-bass sidechaining to clean up the low end, though the effect is usually more transparent in those genres.\n\nCommon variations:\n- If your kick has a long tail or sub-bass that extends beyond the transient, adjust the release to match that decay.\n- If the ducking feels too obvious, reduce the ratio or increase the threshold (which reduces how much the compressor engages).\n- For electronic music with perfectly quantized, four-on-the-floor kicks, you can use a volume shaper plugin like LFO Tool or Cableguys ShaperBox instead of a compressor. These let you literally draw the volume curve, avoiding compression artifacts entirely.",
+            "symbolName": "waveform.path",
+            "visualTitle": "Kick-Bass Ducking Setup",
+            "visualCaption": "Bass ducks when kick hits.",
+            "settings": {
+              "Attack": "0.1-5ms (instant response)",
+              "Release": "50-150ms (tempo/groove dependent)",
+              "Ratio": "3:1 to 6:1 (transparent to obvious)",
+              "Gain Reduction Target": "3-6dB per kick hit"
+            },
+            "proTip": "Set your compressor's release time by playing the track and adjusting the knob until the gain-reduction meter 'breathes' with the rhythm—bouncing down and recovering in sync with the groove.",
+            "avoidThis": "Don't set threshold so low that the compressor is always compressing, even when the kick isn't playing. The bass should return to full volume between kicks.",
+            "checkYourWork": "Your kick drum is punchy and clear, the bass has rhythmic movement, and the low end sounds tight in both stereo and mono playback.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step2_kick_bass_compressor.png"
+          },
+          {
+            "number": 43,
+            "title": "Visual Analysis: Kick-Bass Interaction",
+            "concept": "Understanding the waveform and frequency interaction between kick and bass helps you visualize what sidechaining accomplishes.",
+            "actions": [
+              "Use a spectrum analyzer to see frequency overlap between kick and bass.",
+              "Observe the gain-reduction meter on the bass compressor to verify ducking timing.",
+              "Compare the waveform before and after sidechain compression to see the volume reduction."
+            ],
+            "body": "Visual feedback is essential for dialing in effective kick-bass sidechaining. Logic Pro's built-in metering, along with the Channel EQ's analyzer and third-party spectrum analyzers, help you see what's happening in the frequency spectrum.\n\nBefore sidechaining, place Logic's Channel EQ on both the kick and bass tracks (set to Analyzer mode without making EQ changes). Play the section where kick and bass play together. You'll see both tracks' energy concentrated in the 40-80Hz range, with peaks likely overlapping. This overlap is where masking occurs—both sounds are fighting for the same frequency space.\n\nAfter setting up sidechain compression, watch the gain-reduction meter on the bass compressor. You should see the meter respond rhythmically, showing 3-6dB of reduction each time the kick hits, then releasing back to zero before the next kick. If the meter shows constant compression (never fully releasing), your threshold is too low. If it barely moves, your threshold is too high or your ratio is too gentle.\n\nIn the Arrange window, you can visually compare the bass waveform before and after sidechaining by duplicating the bass track, applying sidechain compression to one, and bouncing both to audio for side-by-side comparison. The sidechained version will show distinct 'dips' in amplitude aligned with each kick hit.\n\nSome producers use oscilloscope plugins (like s(M)exoscope or Youlean Loudness Meter's waveform view) to see the actual waveform interaction in real-time. When kick and bass are properly sidechained, you'll see the bass waveform 'duck' or reduce in amplitude precisely when the kick waveform appears.\n\nThis visual approach is especially helpful when learning sidechaining. Once you develop an ear for it, you'll rely more on listening, but visual confirmation speeds up the learning process and helps troubleshoot problems like incorrect release timing or insufficient gain reduction.",
+            "symbolName": "chart.xyaxis.line",
+            "visualTitle": "Frequency Spectrum Analysis",
+            "visualCaption": "See the overlap and the solution.",
+            "settings": {
+              "Key Frequency Range": "40-80Hz (kick/bass fundamental)",
+              "Visual Tools": "Channel EQ analyzer, gain-reduction meter, spectrum analyzer",
+              "Metering Goal": "3-6dB GR on kick hits, full release between"
+            },
+            "proTip": "Use Logic's 'Split by Channel' feature on a stereo analyzer to compare kick and bass frequencies side-by-side, making overlap immediately obvious.",
+            "avoidThis": "Don't rely solely on visual metering—always use your ears to verify that the ducking feels musical and grooves with the track.",
+            "checkYourWork": "You can see the frequency overlap before sidechaining and observe the gain-reduction meter responding rhythmically after sidechaining.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step3_spectrum_analysis.png"
+          },
+          {
+            "number": 44,
+            "title": "Vocal Clarity: Music Bus Sidechaining",
+            "concept": "Routing melodic instruments through a sidechain-compressed bus triggered by vocals creates transparent space for lyrics without obvious ducking.",
+            "actions": [
+              "Create an auxiliary track and route guitars, keys, pads, and backing vocals to it.",
+              "Insert a compressor on the aux track and set its sidechain input to the lead vocal.",
+              "Use gentle settings: 3:1 to 4:1 ratio, 5-10ms attack, 80-150ms release.",
+              "Target 1-3dB of gain reduction during vocal phrases."
+            ],
+            "body": "One of the most powerful but under-discussed applications of sidechaining is creating space for lead vocals by gently compressing the entire musical bed when the vocal is present. This technique is standard in professional pop, rock, and hip-hop mixing, but it's so transparent that most listeners never consciously notice it.\n\nThe problem: when a dense arrangement plays—full band with guitars, keys, pads, synths, backing vocals—the lead vocal can get masked, especially in the 1kHz to 3kHz range where vocal intelligibility lives. You could boost the vocal with EQ or simply turn it up, but this often makes it feel disconnected from the track. Instead, subtly reducing everything else when the vocal is present makes the vocal feel embedded in the mix while remaining clear.\n\nHere's the setup:\n\n1. Create a new auxiliary (bus) track. Name it something like 'Music Bus' or 'Sidechain Aux.'\n\n2. Route all melodic and harmonic tracks to this aux. This typically includes: electric guitars, acoustic guitars, keyboards, synths, pads, strings, backing vocals, and any other mid-range-heavy elements. Do NOT route drums, bass, or lead vocals to this bus—those stay independent.\n\n3. Insert Logic's Compressor on the Music Bus aux track.\n\n4. In the compressor, set the Side Chain input to your lead vocal track.\n\n5. Configure the compressor with these settings:\n   - Ratio: 3:1 to 4:1 (gentle, transparent)\n   - Attack: 5ms to 10ms (fast enough to respond to vocal transients, but not so fast that it creates artifacts)\n   - Release: 80ms to 150ms (should recover between vocal phrases, not during sustained notes)\n   - Knee: Soft (for smooth, gradual compression)\n   - Threshold: adjust until you see 1dB to 3dB of gain reduction when the vocal is singing. During instrumental breaks (no vocal), the compressor should show zero gain reduction.\n\n6. Do not add makeup gain—you want the music to genuinely get quieter when the vocal is present.\n\n7. Solo the vocal and the music bus together, then play a dense section (like a chorus with full instrumentation). You should hear the music subtly 'breathe' around the vocal—ducking slightly when the vocal is loud, swelling back up during rests and between words.\n\nThe beauty of this technique is its transparency. If done correctly, the listener doesn't hear 'pumping' or obvious volume changes—they simply hear a vocal that's clear and present without sounding disconnected. The vocal feels 'in the pocket' of the mix.\n\nThis method is far superior to traditional automation for several reasons:\n- It's automatic: the compressor responds to every vocal phrase without manual rides.\n- It's consistent: every time that vocal phrase plays, the same amount of ducking happens.\n- It's frequency-neutral: unlike EQ, which changes tone, this simply creates dynamic space.\n\nCommon variations:\n- If the ducking is too obvious, reduce the ratio to 2:1 or raise the threshold so less compression happens.\n- If the vocal still isn't cutting through, check if your release time is too fast (causing the music to swell back up too quickly) or if your attack is too slow (letting initial consonants get masked).\n- For more surgical control, use dynamic EQ sidechaining (covered in Step 7) to target only the 1-3kHz vocal range instead of compressing the entire music bus.",
+            "symbolName": "music.note.list",
+            "visualTitle": "Music Bus Method",
+            "visualCaption": "Melodic elements duck for vocal clarity.",
+            "settings": {
+              "Ratio": "3:1 to 4:1",
+              "Attack": "5-10ms",
+              "Release": "80-150ms",
+              "Gain Reduction": "1-3dB during vocal phrases"
+            },
+            "proTip": "If your mix has both a verse and a chorus vocal, use the loudest vocal section (usually the chorus) to set your threshold. The compressor will naturally compress less during quieter verse vocals, creating dynamic variation.",
+            "avoidThis": "Don't route drums or bass to the music bus—sidechaining these creates an unstable, pumping low end. Keep the rhythm section independent.",
+            "checkYourWork": "Your lead vocal is consistently clear and intelligible without sounding louder or disconnected from the track. The music subtly breathes around the vocal.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step4_music_bus_routing.png"
+          },
+          {
+            "number": 45,
+            "title": "Podcast and Voiceover Ducking",
+            "concept": "Sidechaining background music to dialogue tracks ensures spoken words remain intelligible while maintaining atmospheric support.",
+            "actions": [
+              "Place a compressor on your background music or sound effects track.",
+              "Set the sidechain input to your dialogue or voiceover track.",
+              "Use aggressive settings for instant, obvious ducking: 8:1 ratio, <1ms attack, 200-500ms release.",
+              "Target 6-12dB of gain reduction to guarantee dialogue clarity."
+            ],
+            "body": "In podcasts, audiobooks, video production, and film mixing, dialogue clarity is paramount. Listeners need to understand every word without straining, even if background music or ambient sound effects are present. Sidechain compression automates this balance, ensuring music ducks the moment someone speaks and returns when they stop.\n\nUnlike musical sidechaining (which is often subtle), podcast/voiceover ducking is usually obvious and aggressive. The goal is not transparency—it's absolute dialogue priority. Listeners expect background elements to reduce in volume when speech is present, and this ducking is considered standard, professional behavior.\n\nSetup for podcast/voiceover ducking:\n\n1. Arrange your session with dialogue/voiceover on one track and background music/ambience on a separate track (or aux bus if you have multiple background elements).\n\n2. Insert a compressor on the background music track.\n\n3. Set the compressor's sidechain input to the dialogue track.\n\n4. Configure aggressive settings:\n   - Ratio: 8:1 to ∞:1 (limiter-style, for strong ducking)\n   - Attack: 0.1ms to 1ms (instant response to speech)\n   - Release: 200ms to 500ms (should swell back up during natural pauses, not during mid-sentence breaths)\n   - Threshold: adjust until you see 6dB to 12dB of gain reduction whenever dialogue is present. This ensures the background drops significantly, leaving room for speech.\n\n5. Test by playing sections with continuous dialogue. The background music should drop to roughly 25-40% of its normal volume, making dialogue effortlessly clear. During silent sections (no dialogue), the music should return to full volume.\n\n6. Pay special attention to the release time. If it's too fast (under 100ms), the music will pump up and down during natural speech rhythm, sounding unnatural. If it's too slow (over 1 second), the music won't return to full volume during intentional pauses or between speakers, making those pauses feel awkward.\n\nThis technique is so common in podcast production that many podcast-specific tools (like iZotope RX's Dialogue Isolate or dedicated podcast mixing plugins) include preset 'music ducking' modes that essentially automate this exact sidechain compression setup.\n\nFor video production (YouTube, corporate videos, e-learning), this same technique is used to duck background music under narration. Some video editors even automate this in post-production software (Premiere Pro, Final Cut Pro) using built-in audio ducking features, but doing it in Logic Pro during audio post-production gives you more precise control over the compression character.\n\nVariations:\n- For multi-speaker podcasts, route all dialogue tracks to a dialogue bus, then use that bus as the sidechain source. This way, background music ducks when any speaker talks.\n- For audiobooks, you might want less aggressive ducking (4:1 ratio, 3-6dB GR) if the background music is meant to remain present but supportive.\n- For film mixing, you may need to sidechain multiple background layers (music, ambience, effects) separately to the dialogue, giving you granular control over how much each element ducks.",
+            "symbolName": "mic.fill",
+            "visualTitle": "Dialogue Ducking",
+            "visualCaption": "Speech always clear over background.",
+            "settings": {
+              "Ratio": "8:1 to ∞:1",
+              "Attack": "0.1-1ms",
+              "Release": "200-500ms",
+              "Gain Reduction": "6-12dB during dialogue"
+            },
+            "proTip": "Add a high-pass filter to the sidechain input (covered in Step 11) to prevent low-frequency rumble or plosives from triggering the compressor—only mid-range speech frequencies should trigger ducking.",
+            "avoidThis": "Don't use slow attack times (over 10ms) for dialogue ducking—the first syllable of each word may get masked before the compressor engages.",
+            "checkYourWork": "Every word of dialogue is effortlessly clear, and background music feels present during pauses but never competes with speech.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step5_podcast_ducking.png"
+          },
+          {
+            "number": 46,
+            "title": "Reverb Sidechaining for Vocal Clarity",
+            "concept": "Sidechaining vocal reverb to the dry vocal prevents long, washy tails from obscuring lyrics while maintaining a sense of space.",
+            "actions": [
+              "Create a reverb send/return for vocals (aux track with reverb plugin).",
+              "Insert a compressor after the reverb on the aux return.",
+              "Set the compressor's sidechain input to the dry vocal track.",
+              "Use moderate settings: 4:1 ratio, 5-10ms attack, 50-150ms release, targeting 3-6dB GR."
+            ],
+            "body": "Reverb is essential for placing vocals in a believable acoustic space, but long reverb tails can smear lyrics and reduce intelligibility, especially in dense mixes. The traditional solution is to shorten the reverb decay time, but this sacrifices the lush, immersive quality that makes reverb effective. Sidechain compression on the reverb return offers a better solution: let the reverb ring freely during pauses and sustained notes, but duck it when new lyrics arrive.\n\nThis technique is widely used in modern pop, worship music, and ballad production. It allows for dramatic, long-decay reverbs that don't cloud fast lyrical passages.\n\nSetup:\n\n1. Create a standard reverb send/return setup: insert a Send on your lead vocal track, routing it to an auxiliary track. On that aux, insert a reverb plugin (Space Designer, ChromaVerb, or your preferred reverb).\n\n2. After the reverb plugin on the aux return, insert Logic's Compressor.\n\n3. Set the compressor's sidechain input to the dry lead vocal track (not the aux—you want the compressor to 'hear' the original vocal, not the reverb).\n\n4. Configure the compressor:\n   - Ratio: 4:1 to 6:1 (moderate, musical compression)\n   - Attack: 5ms to 10ms (fast enough to respond to new lyrics, slow enough to avoid clicks)\n   - Release: 50ms to 150ms (should release during sustained notes, not instantly)\n   - Threshold: adjust until you see 3dB to 6dB of gain reduction when the vocal is singing. The reverb should duck noticeably, but not disappear.\n\n5. Solo the vocal and reverb aux together. As the vocal sings, the reverb should reduce in level, creating space for the dry vocal. When the vocal sustains a note or pauses, the reverb should swell back up, filling the space with ambience.\n\n6. The result: you can use a 2.5-second reverb decay (which would normally blur fast lyrics) because it's being ducked when the vocal is active and only fully audible during gaps.\n\nThis technique transforms how you approach reverb in dense mixes. You're no longer limited to short, safe decay times—you can use long, lush reverbs that automatically get out of the way when needed.\n\nVariations:\n- For even more surgical control, use a dynamic EQ (like FabFilter Pro-Q 3 or Waves F6) on the reverb return, sidechained to the vocal, targeting only the 1-3kHz midrange. This ducks the 'body' of the reverb without affecting the highs or lows, preserving shimmer and depth.\n- For duet vocals, route both vocalists to the same reverb aux, then sidechain that reverb to a bus containing both vocal tracks. The reverb will duck when either singer is active.\n- If the ducking sounds too obvious, reduce the ratio to 3:1 or increase the release time so the reverb recovers more gently.",
+            "symbolName": "sparkles",
+            "visualTitle": "Reverb Sidechaining",
+            "visualCaption": "Lush reverb that doesn't smear lyrics.",
+            "settings": {
+              "Ratio": "4:1 to 6:1",
+              "Attack": "5-10ms",
+              "Release": "50-150ms",
+              "Gain Reduction": "3-6dB when vocal is active"
+            },
+            "proTip": "Use a longer release time (150ms+) for ballads and slow songs where you want the reverb to feel 'always there.' Use shorter release (50ms) for fast, rhythmic vocal passages.",
+            "avoidThis": "Don't apply this technique to every reverb in your mix—only reverbs on lead elements where clarity matters. Background vocal reverbs, for example, can usually stay untouched.",
+            "checkYourWork": "Your vocal reverb feels spacious and dramatic, but lyrics remain clear even during fast, dense passages. The reverb is most noticeable during pauses and sustained notes.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step6_reverb_sidechain.png"
+          },
+          {
+            "number": 47,
+            "title": "Delay Sidechaining for Clean Repeats",
+            "concept": "Sidechaining delay returns to the dry source prevents delay repeats from cluttering the mix during continuous performance.",
+            "actions": [
+              "Set up a delay send/return on an aux track.",
+              "Insert a compressor after the delay plugin on the aux.",
+              "Sidechain the compressor to the dry source track.",
+              "Use settings similar to reverb sidechaining: 4:1, 5ms attack, 50-150ms release."
+            ],
+            "body": "Delay effects add depth, space, and interest, but long delay tails or multiple repeats can clutter a mix, especially when the source instrument or vocal is playing continuously. Sidechaining the delay return creates a clean, professional sound where delay is audible during gaps but doesn't compete with the dry signal.\n\nThis technique is particularly useful for:\n- Vocal delays where you want distinct echoes at the end of phrases but not during active singing.\n- Guitar delays in dense rock or pop mixes.\n- Dub-style delay throws where the effect is dramatic but shouldn't mask the original performance.\n\nSetup (identical structure to reverb sidechaining):\n\n1. Create a delay send/return: insert a Send on your source track (vocal, guitar, etc.), routing to an auxiliary track. On the aux, insert a delay plugin (Delay Designer, Stereo Delay, Tape Delay, or Echo).\n\n2. After the delay plugin on the aux, insert Logic's Compressor.\n\n3. Set the compressor's sidechain input to the dry source track.\n\n4. Configure the compressor:\n   - Ratio: 4:1 to 6:1\n   - Attack: 5ms to 10ms\n   - Release: 50ms to 150ms (adjust based on delay time—longer delay times may benefit from longer release)\n   - Threshold: adjust until you see 3-6dB of gain reduction when the source is playing. The delay should duck but remain subtly audible.\n\n5. Test with a phrase that has distinct gaps. The delay repeats should be clearly audible during pauses but should sit behind the dry signal when the source is active.\n\n6. For dramatic delay throws (common in EDM, dub, and reggae), increase the ratio to 8:1 or higher so the delay almost disappears when the source plays, then swells up dramatically during gaps.\n\nThis technique is especially powerful for quarter-note or eighth-note delay settings where repeats would otherwise stack up and create rhythmic clutter. With sidechaining, you get the rhythmic interest of timed delays without the mud.\n\nVariations:\n- For ping-pong or stereo delays, apply the sidechain compression after the delay plugin but before any stereo imaging. This keeps the delay's spatial character intact while still ducking its overall level.\n- For feedback-heavy delays (where repeats go on for many cycles), sidechaining prevents the buildup from becoming overpowering.\n- For delay throws on specific words or phrases, consider automating the delay send level instead of relying on sidechaining—this gives you more surgical control over which words get delayed.",
+            "symbolName": "arrow.forward.circle",
+            "visualTitle": "Delay Sidechain Setup",
+            "visualCaption": "Clean repeats during gaps, subtle during performance.",
+            "settings": {
+              "Ratio": "4:1 to 6:1 (or 8:1+ for dramatic ducking)",
+              "Attack": "5-10ms",
+              "Release": "50-150ms",
+              "Gain Reduction": "3-6dB when source is active"
+            },
+            "proTip": "Match the compressor's release time to your delay time for musical interaction. For a quarter-note delay at 120 BPM (500ms delay), try a 200-300ms release so the delay swells back up just before the next repeat.",
+            "avoidThis": "Don't sidechain delay on every track—use it selectively where the delay would otherwise clutter the mix. Simple, short delays often don't need sidechaining.",
+            "checkYourWork": "Delay repeats are distinct and clear during pauses, but don't compete with or muddy the dry source when it's playing.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step7_delay_sidechain.png"
+          },
+          {
+            "number": 48,
+            "title": "Creative Pumping: EDM and Electronic Music",
+            "concept": "Aggressive sidechain compression with exaggerated settings creates the signature 'pumping' effect in electronic dance music.",
+            "actions": [
+              "Sidechain melodic elements (synths, pads, bass, leads) to the kick drum.",
+              "Use extreme settings: 8:1 to ∞:1 ratio, 0.1ms attack, tempo-synced release.",
+              "Target heavy gain reduction: 6-12dB or more for obvious pumping.",
+              "Experiment with release curves and timing for rhythmic character."
+            ],
+            "body": "In electronic dance music—especially house, techno, trance, and future bass—sidechain compression isn't just a mixing tool; it's a core production element. The exaggerated 'pumping' or 'breathing' effect where the entire mix rhythmically ducks around the kick drum is a deliberate aesthetic choice that creates energy, movement, and dancefloor impact.\n\nThis technique became famous in French house (Daft Punk, Justice) and is now ubiquitous in mainstream EDM. The pumping is obvious and intentional—listeners expect it and associate it with the genre.\n\nSetup for creative pumping:\n\n1. Identify which elements should pump. Typically: bass, synth pads, lead synths, plucks, and melodic elements. Drums (other than kick), vocals, and high-end percussion often stay independent for clarity.\n\n2. You can either:\n   - Place a sidechain compressor on each individual track (more control, more CPU).\n   - Route all pumping elements to a single aux bus and compress that bus (easier, more cohesive pumping).\n\n3. For individual tracks or the pumping bus, insert a compressor and set the sidechain input to your kick drum.\n\n4. Configure aggressive settings:\n   - Ratio: 8:1 to ∞:1 (limiter-style compression for maximum pumping)\n   - Attack: 0.1ms to 1ms (instant response to kick transient)\n   - Release: Tempo-synced to your track's BPM. For four-on-the-floor kicks, try setting release so the compressor fully recovers just before the next kick hit. Many compressors offer a 'Note' or 'Sync' release mode—set it to 1/4 note or 1/8 note depending on your kick pattern.\n   - Threshold: adjust until you see 10-15dB of gain reduction on each kick. You want obvious, heavy pumping.\n\n5. Listen to the groove. The pumping should feel rhythmic and musical, not arbitrary. If the release is too fast, the pump will feel abrupt and disconnected. If it's too slow, the elements won't recover before the next kick, creating a constant squashed feeling.\n\n6. The result: every time the kick hits, the entire musical bed ducks dramatically, then swells back up, creating a rhythmic 'breathing' that drives the energy of the track.\n\nMany producers use dedicated sidechain tools instead of traditional compressors for this application:\n- **Volume Shapers** (like Cableguys VolumeShaper or LFO Tool): These let you literally draw the volume envelope, giving you total control over the pump curve. You can create sharp, aggressive ducks or smooth, gentle swells.\n- **Nicky Romero Kickstart**: A plugin designed specifically for EDM-style pumping, with presets and tempo-sync features.\n- **Xfer Records LFO Tool**: Industry-standard for precise control over pumping curves.\n\nThese tools avoid compression artifacts (distortion, tone shift) because they're simply controlling volume, not actually compressing the signal. This can result in cleaner, more controlled pumping.\n\nCreative variations:\n- Pump only specific frequency ranges using multiband sidechain (covered in Step 9). For example, pump the mids and lows but leave the high-end shimmer untouched.\n- Use different release times on different elements: pump pads slowly and heavily, but pump bass quickly for a tighter feel.\n- Automate the sidechain intensity: heavy pumping during buildups and drops, lighter pumping during verses.",
+            "symbolName": "waveform.and.magnifyingglass",
+            "visualTitle": "EDM Pumping Effect",
+            "visualCaption": "Obvious, rhythmic ducking for energy.",
+            "settings": {
+              "Ratio": "8:1 to ∞:1",
+              "Attack": "0.1-1ms",
+              "Release": "Tempo-synced (1/4 or 1/8 note)",
+              "Gain Reduction": "10-15dB or more"
+            },
+            "proTip": "For the cleanest, most controlled pumping, use a volume shaper plugin instead of a compressor—you'll avoid compression artifacts and get precise control over the envelope shape.",
+            "avoidThis": "Don't pump everything including drums (other than kick) and vocals—keep some elements stable so the mix doesn't feel chaotic and unstable.",
+            "checkYourWork": "The pumping is obvious, rhythmic, and musical. It drives the energy of the track and feels locked to the groove, not arbitrary or random.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step8_edm_pumping.png"
+          },
+          {
+            "number": 49,
+            "title": "Dynamic EQ Sidechaining: Surgical Frequency Control",
+            "concept": "Sidechain-triggered dynamic EQ ducks only specific frequency ranges instead of entire tracks, creating transparent space without obvious volume changes.",
+            "actions": [
+              "Use a dynamic EQ plugin (FabFilter Pro-Q 3, Waves F6, or Logic's built-in multiband compressor as a workaround).",
+              "Set the sidechain input to the triggering track (e.g., vocal).",
+              "Target the frequency range where masking occurs (e.g., 1-3kHz for vocal clarity).",
+              "Apply moderate reduction: 2-4dB in the targeted frequency range."
+            ],
+            "body": "Traditional sidechain compression reduces the overall volume of a track, which can feel heavy-handed and obvious. Dynamic EQ sidechaining is a more surgical approach: it only reduces specific frequency ranges where masking occurs, leaving the rest of the track untouched. This creates transparent space without the 'pumping' artifacts of full-range sidechain compression.\n\nFor example, if your lead vocal is being masked by guitars in the 2-3kHz range, you don't need to compress the entire guitar track—you only need to reduce that specific frequency band when the vocal is present. The guitars' low end, high-end sparkle, and overall punch remain intact. This is the approach modern mix engineers use for professional pop and rock productions.\n\nSetup using FabFilter Pro-Q 3 (the industry-standard dynamic EQ with sidechain):\n\n1. Insert Pro-Q 3 on the track that needs frequency space reduction (e.g., rhythm guitars, pads, or a music bus).\n\n2. Enable a dynamic EQ band by clicking a band point and setting its type to 'Dynamic' (the lightning bolt icon).\n\n3. Set the band's frequency to the range where masking occurs. For vocal clarity, try 1.5-3kHz. For kick-bass separation, try 60-100Hz.\n\n4. Set the band's Q (width) to moderate—not too narrow (which sounds surgical and obvious) but not too wide (which affects too much frequency range). Start with Q around 2-4.\n\n5. In Pro-Q 3's sidechain section (bottom of the interface), set the external sidechain input to your triggering track (e.g., lead vocal).\n\n6. Adjust the dynamic band's threshold and range. Threshold determines how loud the trigger signal must be before reduction happens. Range determines how much reduction is applied (typically 2-4dB for transparency, up to 6-8dB for more obvious ducking).\n\n7. The result: when the vocal sings, the guitars' 2-3kHz range ducks by 3dB, creating space for vocal intelligibility. But the guitars' low-end body and high-end sparkle remain unchanged. The listener hears clear vocals without noticing any compression or pumping.\n\nFor Logic Pro users without third-party dynamic EQ:\n- Use Logic's Multipressor as a workaround: split the frequency spectrum into bands, then use external sidechain on the band(s) you want to duck. This is less elegant than Pro-Q 3 but effective.\n- Alternatively, use Trackspacer (a dedicated sidechain dynamic EQ plugin) which automatically analyzes the trigger signal and carves out space in the target track.\n- Or use standard sidechain compression with a sidechain EQ filter (covered in Step 11) to make the compressor only 'hear' specific frequencies. This is less precise than true dynamic EQ but can work for simple cases.\n\nDynamic EQ sidechaining is particularly useful for:\n- Vocal clarity in dense pop/rock mixes.\n- Podcast/voiceover where you want to duck music's midrange without affecting bass and treble.\n- Kick-bass separation where you want to duck the bass's 60-80Hz fundamental without affecting its upper harmonics.\n- Reducing sibilance clashes between lead and backing vocals (duck the backing vocals' 6-8kHz range when the lead vocal is present).",
+            "symbolName": "waveform.path.ecg",
+            "visualTitle": "Dynamic EQ Sidechain",
+            "visualCaption": "Target frequencies, not entire tracks.",
+            "settings": {
+              "Common Ranges": "Vocals: 1.5-3kHz, Kick-Bass: 60-100Hz, Sibilance: 6-8kHz",
+              "Reduction Amount": "2-4dB for transparency, 6-8dB for obvious space",
+              "Q (Width)": "2-4 (moderate, musical)",
+              "Tools": "FabFilter Pro-Q 3, Waves F6, Trackspacer, iZotope Neutron"
+            },
+            "proTip": "Use Pro-Q 3's real-time analyzer to visually identify exactly which frequency range is causing masking, then place your dynamic EQ band right on that peak.",
+            "avoidThis": "Don't use overly narrow Q values (10+) which create surgical, obvious dips. Dynamic EQ should be felt, not heard.",
+            "checkYourWork": "Your lead element (vocal, kick, etc.) is clear and present, but the overall tonal balance of supporting tracks remains unchanged. The space creation is transparent.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step9_dynamic_eq.png"
+          },
+          {
+            "number": 50,
+            "title": "Multiband Sidechain Compression",
+            "concept": "Splitting audio into frequency bands and sidechaining only specific bands preserves tonal balance while creating targeted dynamic space.",
+            "actions": [
+              "Use Logic's Multipressor or a third-party multiband compressor.",
+              "Split the frequency spectrum (e.g., Low: <200Hz, Mid: 200-5kHz, High: >5kHz).",
+              "Enable external sidechain on the band(s) you want to duck (typically Low or Mid).",
+              "Leave other bands untouched or use gentle settings."
+            ],
+            "body": "Multiband sidechain compression combines the best aspects of full-range sidechain and dynamic EQ: it splits audio into multiple frequency bands, then applies sidechain compression only to the bands where you need it. This is more flexible than standard sidechain (which affects everything) and easier to set up than dynamic EQ (which requires precision frequency selection).\n\nCommon applications:\n\n**Low-End Ducking:** Sidechain only the low band (<150Hz) of a bass track to the kick, leaving the bass's midrange and harmonic content untouched. This creates kick-bass separation without losing the 'warmth' and 'body' of the bass tone.\n\n**Vocal Clarity:** Sidechain only the midrange band (1-4kHz) of a music bus to the vocal, leaving lows and highs intact. This creates vocal space without affecting the bass or high-frequency shimmer.\n\n**Podcast/VO Ducking:** Sidechain the midrange band of background music to dialogue, leaving the music's bass and treble at full volume. This maintains musical richness while ensuring speech clarity.\n\nSetup in Logic Pro using Multipressor:\n\n1. Insert Logic's Multipressor on the target track (the one that should be affected).\n\n2. Set up your crossover points to split the frequency spectrum. For kick-bass example: Low band up to 150Hz, Mid band 150Hz to 5kHz, High band above 5kHz.\n\n3. For each band you want to sidechain, click the band's settings and enable the external sidechain input. Set it to your trigger track (e.g., kick drum).\n\n4. Configure the compression settings for each sidechained band:\n   - Low band (for kick-bass): Ratio 4:1-6:1, fast attack (0.1ms), moderate release (80-150ms), threshold for 3-6dB GR.\n   - Mid band (for vocal clarity): Ratio 3:1-4:1, 5-10ms attack, 100-200ms release, threshold for 2-4dB GR.\n\n5. Leave bands you don't want to duck either bypassed or set to very gentle settings.\n\n6. The result: you get targeted frequency-specific ducking without affecting the entire tonal balance of the track.\n\nThird-party multiband compressors with better sidechain features:\n- **FabFilter Pro-MB**: Offers up to 6 bands with individual sidechain inputs, per-band attack/release, and excellent visual feedback.\n- **Waves C6**: Industry-standard multiband with sidechain on each band.\n- **iZotope Ozone Dynamics**: Multiband mode with sidechain, often used for mastering-style multiband ducking.\n\nMultiband sidechaining is especially powerful when:\n- You want the benefits of dynamic EQ sidechaining but don't want to invest in FabFilter Pro-Q 3.\n- You need different ducking behavior in different frequency ranges (e.g., aggressive ducking in the lows, gentle ducking in the mids, no ducking in the highs).\n- You're working with complex, full-bandwidth sources (like synth pads or guitar buses) where simple full-range compression would be too heavy-handed.",
+            "symbolName": "square.split.diagonal",
+            "visualTitle": "Multiband Sidechain",
+            "visualCaption": "Frequency-specific ducking with tonal preservation.",
+            "settings": {
+              "Low Band": "<150Hz (kick-bass separation)",
+              "Mid Band": "150Hz-5kHz (vocal clarity)",
+              "High Band": ">5kHz (usually left alone)",
+              "Tools": "Logic Multipressor, FabFilter Pro-MB, Waves C6"
+            },
+            "proTip": "Use multiband sidechain on synth pads and atmospheric elements—duck only the mids for vocal space while leaving the lush low-end sub and high-end shimmer untouched.",
+            "avoidThis": "Don't sidechain all bands equally—that's just standard sidechain with extra CPU load. Use multiband specifically to target problem frequency ranges.",
+            "checkYourWork": "You've created space in the critical frequency range (e.g., low end for kick, mids for vocal) without altering the overall tonal character of the track.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step10_multiband_sidechain.png"
+          },
+          {
+            "number": 51,
+            "title": "Sidechain EQ Filtering for Targeted Triggering",
+            "concept": "Using the sidechain input's built-in EQ filter makes the compressor respond only to specific frequencies, creating more musical and transparent results.",
+            "actions": [
+              "In your sidechain compressor, locate the 'Filter' or 'Side Chain EQ' section.",
+              "Enable filtering and choose a filter type (high-pass, low-pass, or bandpass).",
+              "Set the filter frequency to isolate the trigger signal's most relevant range.",
+              "Test and adjust—the compressor should now respond only to filtered frequencies."
+            ],
+            "body": "By default, when you set up sidechain compression, the compressor 'listens' to the full frequency spectrum of the trigger track. But often, only certain frequencies are relevant. For kick-bass ducking, you only care about the kick's low-frequency thump (40-100Hz), not its high-frequency click. For vocal sidechaining, you only care about the vocal's intelligibility range (1-4kHz), not its breath noise or sibilance.\n\nLogic Pro's Compressor includes a built-in 'Side Chain' filter section that lets you EQ the sidechain input, making the compressor respond only to the frequencies you choose. This creates more musical, transparent compression with fewer artifacts.\n\nCommon filter applications:\n\n**High-Pass Filter (HPF):** Makes the compressor ignore low frequencies. Use this when sidechaining to vocals or dialogue to prevent plosives, breath noise, and low-frequency rumble from triggering compression. Set the HPF to 80-150Hz so the compressor only 'hears' the actual speech/vocal tone.\n\n**Low-Pass Filter (LPF):** Makes the compressor ignore high frequencies. Use this when sidechaining bass to kick—set an LPF around 120-200Hz so the compressor only responds to the kick's fundamental thump, not its beater click or cymbal bleed.\n\n**Bandpass Filter (BPF):** Makes the compressor only 'hear' a specific frequency range. Use this for surgical applications: for example, set a bandpass around 2-3kHz when sidechaining a music bus to vocals, so the compressor only responds to the core vocal intelligibility range.\n\n**Parametric EQ:** Some compressors (including Logic's) offer a parametric bell filter in the sidechain. Use this to emphasize a specific frequency that should trigger compression more strongly. For example, boost 60Hz in the sidechain when compressing bass to kick, making the compressor extra-sensitive to the kick's fundamental.\n\nSetup in Logic Pro's Compressor:\n\n1. Set up your sidechain compression as usual (compressor on target track, sidechain input set to trigger track).\n\n2. In the Compressor interface, locate the 'Side Chain' section (usually collapsed—click the disclosure triangle to expand it).\n\n3. Enable the 'Filter' checkbox.\n\n4. Choose your filter type from the drop-down: LP (low-pass), BP (bandpass), HP (high-pass), ParEQ (parametric), or HS (high shelf).\n\n5. Adjust the filter frequency and Q (width) to target your desired range. For example:\n   - Kick-bass with LPF: Set frequency to 150Hz so only low-end triggers compression.\n   - Vocal clarity with BPF: Set center frequency to 2.5kHz, Q around 1.5, so only vocal presence range triggers compression.\n   - Dialogue ducking with HPF: Set frequency to 100Hz to ignore rumble and plosives.\n\n6. Listen and adjust. The compressor's behavior will change—it should now respond more musically and predictably because it's only 'hearing' the relevant frequencies.\n\nThis technique is incredibly powerful but often overlooked. It can transform overly aggressive sidechain compression into smooth, musical ducking simply by making the compressor ignore irrelevant frequency content.\n\nThird-party compressors often have even more sophisticated sidechain filtering:\n- **FabFilter Pro-C 2:** Includes a built-in sidechain EQ with full parametric controls and real-time spectrum analysis.\n- **Waves Renaissance Compressor:** Offers sidechain high-pass and low-pass filters.\n- **SSL Native Bus Compressor:** Includes the famous SSL sidechain filter controls (SC HPF).",
+            "symbolName": "slider.vertical.3",
+            "visualTitle": "Sidechain Filter Control",
+            "visualCaption": "Make compressor respond only to relevant frequencies.",
+            "settings": {
+              "HPF (vocal/dialogue)": "80-150Hz (ignore rumble)",
+              "LPF (kick-bass)": "120-200Hz (only thump triggers)",
+              "BPF (vocal clarity)": "2-3kHz center (presence range)",
+              "ParEQ": "Boost or cut to emphasize specific triggers"
+            },
+            "proTip": "Use FabFilter Pro-C 2's sidechain audition feature (headphone icon) to solo what the compressor is 'hearing'—this makes dialing in the perfect filter setting instant and obvious.",
+            "avoidThis": "Don't use extremely narrow bandpass filters (Q > 10) unless you have a very specific reason—this can make the compressor respond inconsistently as the trigger track's frequency content varies.",
+            "checkYourWork": "Your sidechain compression responds smoothly and predictably, with fewer false triggers and more musical ducking that follows the most important elements of the trigger signal.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step11_sidechain_filter.png"
+          },
+          {
+            "number": 52,
+            "title": "Gate Sidechaining for Rhythmic Effects",
+            "concept": "Using a sidechain-triggered gate creates rhythmic chopping, stuttering, and on/off effects synchronized to a trigger track.",
+            "actions": [
+              "Insert Logic's Noise Gate on the track you want to rhythmically chop.",
+              "Set the gate's sidechain input to a rhythmic trigger (kick, hi-hat, or dedicated trigger track).",
+              "Use fast attack (0.1ms), adjust threshold for full gating, and set hold/release for desired effect length.",
+              "Create dramatic rhythmic effects synchronized to another element."
+            ],
+            "body": "While most sidechaining discussions focus on compression (which reduces volume), gate sidechaining is equally powerful for creative production. A noise gate silences audio when the trigger signal is below a threshold—when sidechained, this means the target track only plays when the trigger is present. This creates rhythmic chopping, stuttering, and gating effects that are perfectly locked to another element's rhythm.\n\nCommon creative applications:\n\n**Rhythmic Pad Gating:** Sidechain a lush pad or string sound to a kick or hi-hat pattern. The pad will only play when the trigger hits, creating a rhythmic, pulsing texture instead of a sustained drone. This is common in trance, techno, and progressive house.\n\n**Vocal Chopping:** Sidechain a vocal sample to a rhythmic MIDI trigger track (silent, used only for triggering). Create a MIDI pattern with the rhythm you want, then use it to 'slice' the vocal into rhythmic fragments.\n\n**Bass Gating:** Sidechain a sustained bass note to a kick or hi-hat. The bass will play in sync with the drums, creating a staccato, rhythmic bass line from what was originally a long sustained note.\n\n**Reverse Ducking (Creative Effect):** Use a gate sidechained to kick to make a synth or pad *only* play when the kick hits, creating a pumping effect that's the opposite of standard sidechain compression.\n\nSetup:\n\n1. Insert Logic's Noise Gate on the track you want to rhythmically chop (target).\n\n2. Set the gate's 'Side Chain' input to your trigger track (kick, hi-hat, or a dedicated MIDI trigger track).\n\n3. Configure the gate:\n   - Threshold: Set high enough that the target track is fully gated (silent) when the trigger is not present. You'll need to adjust by ear—start around -20dB and increase until you hear complete silence between triggers.\n   - Attack: Set to fastest (0.1ms) for instant gating, or slower (10-50ms) for a fade-in effect on each gate opening.\n   - Hold: Determines how long the gate stays open after the trigger stops. For short, staccato effects, use 10-50ms. For longer, more sustained gates, use 100-300ms.\n   - Release: How quickly the gate closes (fades out) after the hold time. Fast release (10-50ms) creates abrupt cuts. Slower release (100-300ms) creates smooth fade-outs.\n\n4. Test different trigger sources:\n   - Sidechain to kick for four-on-the-floor rhythmic gating.\n   - Sidechain to hi-hats for faster, more intricate rhythmic patterns.\n   - Sidechain to a custom MIDI trigger track for complete rhythmic control.\n\n5. Experiment with attack/hold/release to shape the character of the gating. Short settings create stuttering, glitchy effects. Long settings create smooth, pulsing textures.\n\nAdvanced techniques:\n- Use the gate's 'Hysteresis' control (if available) to prevent flutter when the trigger signal is near the threshold.\n- Combine gate sidechaining with volume automation for hybrid effects: gate for rhythmic structure, automation for musical phrasing.\n- Use a multiband gate (or split your signal into bands and gate each separately) for frequency-specific rhythmic gating—for example, gate only the midrange of a pad while leaving bass and treble sustained.\n\nGate sidechaining is less common in traditional mixing but extremely popular in electronic production, sound design, and remix work. It's a fast way to create complex rhythmic patterns from static, sustained sounds.\n\nThird-party gate plugins with advanced sidechain features:\n- **FabFilter Pro-G:** Industry-standard gate with sidechain input, per-band gating, and visual metering.\n- **Waves Renaissance DeEsser/Gate:** Classic gate with sidechain.\n- **Logic's own Enveloper:** While not technically a gate, it can be sidechained and used for similar rhythmic effects.",
+            "symbolName": "bolt.horizontal.circle",
+            "visualTitle": "Rhythmic Gate Sidechain",
+            "visualCaption": "Chop and slice in sync with triggers.",
+            "settings": {
+              "Attack": "0.1ms (instant) or 10-50ms (fade-in)",
+              "Hold": "10-50ms (staccato) or 100-300ms (sustained)",
+              "Release": "10-50ms (abrupt) or 100-300ms (smooth)",
+              "Threshold": "Adjust for complete gating"
+            },
+            "proTip": "Create a dedicated MIDI trigger track with no sound output—just MIDI notes—then use it to sidechain-gate any audio track. This gives you complete rhythmic control without being tied to existing drum patterns.",
+            "avoidThis": "Don't use gate sidechaining on lead vocals or primary melodic elements in traditional mixes—it's too destructive. Reserve it for creative production and sound design.",
+            "checkYourWork": "Your target track plays only when the trigger is active, creating a tight, rhythmic effect that's perfectly locked to the groove. The gating is clean without clicks or artifacts.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step12_gate_sidechain.png"
+          },
+          {
+            "number": 53,
+            "title": "Creative Auto-Filter Sidechaining",
+            "concept": "Sidechain-triggered auto-filters create dynamic tone changes synchronized to other tracks, useful for rhythmic filtering and movement.",
+            "actions": [
+              "Insert Logic's Auto Filter on the track you want to affect.",
+              "Set the filter type (low-pass, high-pass, or bandpass) and configure cutoff/resonance.",
+              "Enable sidechain input and select your trigger track.",
+              "Adjust envelope controls to shape how the filter responds to the trigger."
+            ],
+            "body": "Beyond compression and gating, Logic Pro's Auto Filter plugin supports sidechain input, allowing filter cutoff to be modulated by external audio sources. This creates dynamic, rhythmic filtering effects where a track's tone changes in response to another element—common in electronic music, dub, and creative sound design.\n\nApplications:\n\n**Rhythmic Low-Pass Filtering:** Sidechain a synth pad's Auto Filter to the kick. The pad's brightness increases when the kick hits, then dulls between kicks, creating rhythmic movement.\n\n**Dub-Style High-Pass Sweeps:** Sidechain a bass or guitar's Auto Filter to a hi-hat or shaker. The filter opens and closes rhythmically, creating classic dub/reggae filtering effects.\n\n**Dynamic Vocal Effects:** Sidechain a doubled vocal or harmony's Auto Filter to the lead vocal. The doubled vocal's tone shifts when the lead sings, creating space and movement.\n\nSetup:\n\n1. Insert Logic's Auto Filter on your target track.\n\n2. Choose a filter type:\n   - Low-Pass (LP): Typical for rhythmic brightness changes.\n   - High-Pass (HP): Useful for creating 'thinning' effects synchronized to triggers.\n   - Band-Pass (BP): For more dramatic, sweeping tonal shifts.\n\n3. Set the cutoff frequency and resonance to taste. Higher resonance creates more pronounced filter 'sweep' character.\n\n4. Enable the Auto Filter's external sidechain input and select your trigger track.\n\n5. Adjust the envelope and dynamics controls:\n   - Attack: How quickly the filter opens when triggered.\n   - Release: How quickly the filter closes after the trigger stops.\n   - Amount: How much the filter cutoff moves (the range of the sweep).\n\n6. The result: when your trigger plays, the filter cutoff moves, changing the target track's tone in sync with the trigger's rhythm.\n\nThis technique is less common in traditional mixing but extremely powerful for:\n- Creating movement and interest in static, sustained sounds (pads, drones).\n- Adding rhythmic complexity without additional instruments.\n- Dub production and remix work where filter sweeps are a core aesthetic element.\n\nAdvanced variations:\n- Combine auto-filter sidechaining with standard sidechain compression for hybrid effects: the track ducks in volume *and* tone simultaneously.\n- Use automation to change the filter's cutoff frequency over time while the sidechain controls the dynamic movement.\n- Route multiple tracks through a bus with a sidechain auto-filter for cohesive, ensemble filtering effects.",
+            "symbolName": "waveform.path.badge.minus",
+            "visualTitle": "Auto-Filter Sidechain",
+            "visualCaption": "Dynamic tone changes synchronized to triggers.",
+            "settings": {
+              "Filter Type": "Low-Pass (brighten/dull), High-Pass (thin/full), Band-Pass (sweeps)",
+              "Cutoff & Resonance": "Set base tone character",
+              "Sidechain Amount": "Controls depth of filter modulation",
+              "Envelope": "Attack/Release shape the filter movement"
+            },
+            "proTip": "Use subtle auto-filter sidechaining on background vocals or doubled instruments to create space for lead elements without obvious volume ducking—the tonal shift is often less noticeable than compression.",
+            "avoidThis": "Don't apply heavy resonance with fast sidechain triggering—this can create harsh, whistling artifacts. Keep resonance moderate for musical results.",
+            "checkYourWork": "Your target track's tone changes rhythmically in sync with the trigger, creating movement and interest without artifacts or harshness.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step13_autofilter_sidechain.png"
+          },
+          {
+            "number": 54,
+            "title": "Troubleshooting Common Sidechaining Problems",
+            "concept": "Understanding common artifacts and issues—pumping, clicks, inconsistent triggering, and over-compression—helps you achieve clean, professional results.",
+            "actions": [
+              "Identify audible artifacts: clicks, pumping, distortion, or loss of energy.",
+              "Check attack/release times: too fast causes clicks, too slow causes sluggish response.",
+              "Verify threshold and ratio: ensure gain reduction is appropriate for the task.",
+              "Use sidechain filtering or dynamic EQ to prevent false triggers."
+            ],
+            "body": "Even with proper setup, sidechain compression can introduce unwanted artifacts or fail to work as intended. Here are the most common problems and their solutions:\n\n**Problem 1: Audible Clicking or Popping**\n- Cause: Attack time is too fast (especially <1ms) or release is too fast with high gain reduction.\n- Solution: Increase attack to 3-10ms for smoother envelope response. Increase release to at least 50ms. Use soft knee for gentler compression onset.\n\n**Problem 2: Obvious, Unmusical Pumping**\n- Cause: Too much gain reduction (10dB+), or release time is out of sync with the track's rhythm.\n- Solution: Reduce ratio (from 8:1 down to 4:1), raise threshold to reduce gain reduction, or adjust release time so the compressor recovers musically (try tempo-synced release). For transparent mixing, aim for 2-6dB GR, not 10dB+.\n\n**Problem 3: Inconsistent or Weak Triggering**\n- Cause: Trigger signal is too quiet, or sidechain filtering is removing the relevant frequencies.\n- Solution: Check that your trigger track (e.g., kick) is actually loud enough to cross the threshold. Disable sidechain filtering temporarily to verify. If the trigger is a drum bus with multiple elements, consider using just the isolated kick for cleaner triggering.\n\n**Problem 4: Compressor Always Compressing (No Recovery)**\n- Cause: Threshold is set too low, or release is too long.\n- Solution: Raise the threshold so the compressor only engages when the trigger actually plays. Shorten release time so the compressor recovers between triggers. Check the gain-reduction meter—it should return to zero between triggers.\n\n**Problem 5: Loss of Energy or 'Dead' Sound**\n- Cause: Too much compression, or you've sidechained too many elements simultaneously.\n- Solution: Reduce the number of sidechained tracks—keep some elements stable for mix energy. Use multiband or dynamic EQ sidechaining instead of full-range compression to preserve tonal balance. Check makeup gain—though typically not needed for sidechaining, extremely heavy compression may benefit from a small amount to restore perceived loudness.\n\n**Problem 6: Distortion or Harsh Artifacts**\n- Cause: Over-compression with high ratio and low threshold, or compressor topology mismatch (some compressors add color/saturation that clashes with the source).\n- Solution: Switch compressor types—use a clean VCA or digital compressor instead of a colored Opto or FET model. Reduce ratio and increase threshold. Use multiband sidechaining to avoid compressing already-distorted frequency ranges.\n\n**Problem 7: Sidechain Not Working At All**\n- Cause: Sidechain routing is incorrect, or plugin doesn't support external sidechain.\n- Solution: Verify the sidechain input is actually set to your trigger track (check the 'Side Chain' menu in the compressor). Ensure the trigger track contains audio and isn't muted or soloed in a way that bypasses the sidechain send. Verify the compressor plugin supports external sidechain (Logic's stock Compressor does; some third-party plugins may not).\n\n**Problem 8: Phase Cancellation or Hollow Sound**\n- Cause: When using parallel or bus-based sidechaining, the sidechained element and non-sidechained elements may be out of phase, especially in the low end.\n- Solution: Use Logic's Gain Utility plugin to flip phase on one of the elements. Check correlation metering. Avoid heavy sidechain compression on low-end elements if phase issues persist—use dynamic EQ or multiband instead.\n\nGeneral troubleshooting workflow:\n1. Bypass the sidechain compressor and compare. If the 'improved' version sounds worse, reduce the intensity or rethink the approach.\n2. Solo the affected track and listen for artifacts (clicks, pumping, distortion) without the rest of the mix.\n3. Check the gain-reduction meter—it should respond rhythmically and predictably. If it's erratic or constantly pinned, your settings need adjustment.\n4. Test in mono. Sidechaining issues (especially phase problems) often become more obvious in mono playback.\n5. Take a break. Ear fatigue makes artifacts harder to identify. Fresh ears catch problems quickly.",
+            "symbolName": "wrench.and.screwdriver",
+            "visualTitle": "Troubleshooting Guide",
+            "visualCaption": "Identify and fix common artifacts.",
+            "settings": {
+              "Clicks": "Increase attack/release, use soft knee",
+              "Pumping": "Reduce ratio, raise threshold, adjust release timing",
+              "Weak Triggering": "Check trigger level, disable sidechain filter",
+              "Always Compressing": "Raise threshold, shorten release",
+              "Distortion": "Lower ratio, switch compressor type"
+            },
+            "proTip": "Create a 'test session' with a simple kick and bass to dial in your preferred sidechain settings. Save these as compressor presets you can recall in future projects.",
+            "avoidThis": "Don't keep adding more compression or stacking multiple sidechain compressors to 'fix' problems—often the solution is less compression, better settings, or a different approach (like dynamic EQ).",
+            "checkYourWork": "Your sidechain compression is transparent and musical (for mixing) or intentionally obvious (for creative effects), with no audible clicks, distortion, or unnatural pumping.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step14_troubleshooting.png"
+          },
+          {
+            "number": 55,
+            "title": "Advanced Workflow: Bus-Based Sidechaining",
+            "concept": "Routing multiple tracks to buses for cohesive sidechain behavior reduces CPU load and creates unified ducking across track groups.",
+            "actions": [
+              "Group related tracks (synths, guitars, pads) onto a bus.",
+              "Apply sidechain compression to the bus instead of individual tracks.",
+              "Use separate buses for different instrument families with unique sidechain needs.",
+              "Reduce CPU load while maintaining consistent, musical ducking."
+            ],
+            "body": "When mixing complex sessions with many tracks, applying individual sidechain compressors to each track is inefficient and can create inconsistent ducking where different elements pump at different rates. Bus-based sidechaining solves this by grouping related tracks onto auxiliary buses and applying a single sidechain compressor to each bus. This creates cohesive, unified ducking and significantly reduces CPU load.\n\nCommon bus groupings for sidechaining:\n\n**Melodic Bus:** Route all synths, keys, pads, and melodic instruments to one aux. Sidechain this bus to the lead vocal for transparent vocal clarity across all melodic content.\n\n**Rhythm Bus (non-kick/bass):** Route percussion, hi-hats, shakers, and rhythm elements to one aux. Sidechain to kick for EDM-style pumping that affects rhythmic layers but not the bass.\n\n**Background Vocal Bus:** Route all backing vocals and harmonies to one aux. Sidechain to lead vocal for automatic space creation without affecting individual backing vocal levels.\n\n**Pad Bus:** Route all atmospheric pads, strings, and ambient textures to one aux. Sidechain to drums or vocal for breathing space in dense sections.\n\nSetup workflow:\n\n1. Identify which tracks have similar sidechaining needs (same trigger source, similar compression settings).\n\n2. Create an auxiliary track for the group. Name it descriptively (e.g., 'Melodic Bus - SC').\n\n3. Route all relevant tracks to this aux by setting their output to the aux bus.\n\n4. Insert a compressor on the aux track and configure sidechain input and settings as usual.\n\n5. The entire group now ducks together, creating cohesive movement. If one synth needs different ducking, split it to a separate bus with unique settings.\n\nBenefits:\n- **CPU Efficiency:** One compressor instance instead of five or ten.\n- **Cohesion:** All elements in the bus duck together, creating unified movement rather than individual pumping.\n- **Mix Glue:** Bus-based sidechaining naturally groups elements sonically, helping them feel like they belong together.\n- **Easier Automation:** You can automate the bus's sidechain intensity (via threshold or ratio) to create dynamic changes (e.g., heavy pumping in the chorus, light pumping in the verse) without touching individual tracks.\n\nAdvanced variations:\n- Use **multiple buses** with different sidechain settings: a 'Heavy SC Bus' for tracks that should pump obviously, and a 'Light SC Bus' for tracks that need subtle ducking.\n- **Parallel sidechain processing:** Route tracks to both a sidechained bus and a non-sidechained bus, then blend them for hybrid ducking intensity.\n- **Nested buses:** Create a master 'Music Bus' with moderate sidechaining, then create sub-buses (guitars, keys, pads) with individual sidechain settings. This gives you both broad and surgical control.\n\nThis approach is standard in professional pop, EDM, and film mixing. It's how engineers manage complex sessions with dozens of tracks while maintaining CPU efficiency and mix cohesion.",
+            "symbolName": "point.3.filled.connected.trianglepath.dotted",
+            "visualTitle": "Bus-Based Sidechaining",
+            "visualCaption": "Group tracks for cohesive ducking.",
+            "settings": {
+              "Melodic Bus": "All synths/keys/melodic → sidechain to vocal",
+              "Rhythm Bus": "All perc (non-kick) → sidechain to kick",
+              "Pad Bus": "All pads/strings → sidechain to drums/vocal",
+              "BG Vocal Bus": "All backing vocals → sidechain to lead vocal"
+            },
+            "proTip": "Create color-coded track labels for sidechained buses so you can quickly identify which elements are being affected at a glance in large sessions.",
+            "avoidThis": "Don't route your entire mix (including drums and bass) to a single sidechained bus—this creates unstable, pumping mixes. Only route elements that genuinely need ducking.",
+            "checkYourWork": "Related tracks duck together as a cohesive group, creating unified movement. CPU load is reduced compared to individual track-by-track sidechaining.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step15_bus_routing.png"
+          },
+          {
+            "number": 56,
+            "title": "Sidechaining in Different Genres",
+            "concept": "Different musical genres have distinct sidechaining conventions—understanding genre expectations helps you apply appropriate techniques.",
+            "actions": [
+              "Identify genre-specific sidechaining norms (transparent for pop/rock, obvious for EDM, functional for podcasts).",
+              "Adjust intensity based on genre: subtle for acoustic/jazz, moderate for pop/hip-hop, extreme for EDM.",
+              "Study reference tracks in your genre to understand sidechaining conventions.",
+              "Balance technical needs (clarity) with creative expectations (pumping)."
+            ],
+            "body": "Sidechaining is not one-size-fits-all. Each genre has different conventions, expectations, and intensity levels. Understanding these norms helps you apply sidechaining appropriately and avoid genre-inappropriate choices.\n\n**Pop Music:**\n- **Approach:** Transparent to moderate. Sidechaining is used for vocal clarity (music bus method) and subtle low-end management (kick-bass ducking).\n- **Settings:** 2:1 to 4:1 ratio, 2-6dB gain reduction, moderate attack/release.\n- **Goal:** Vocals clear and upfront, low end tight, but no obvious pumping. Listeners shouldn't consciously notice the ducking.\n- **Reference:** Taylor Swift, The Weeknd, Ariana Grande—vocals are effortlessly clear without sounding disconnected.\n\n**EDM / Electronic Dance Music (House, Trance, Techno, Future Bass):**\n- **Approach:** Obvious and aggressive. Sidechaining is a production element, not just a mix tool. Heavy pumping creates energy and movement.\n- **Settings:** 8:1 to ∞:1 ratio, 10-15dB+ gain reduction, fast attack (0.1ms), tempo-synced release.\n- **Goal:** Dramatic, rhythmic pumping that grooves with the kick. The effect is intentional and central to the genre's sound.\n- **Reference:** Daft Punk ('One More Time'), Deadmau5, Calvin Harris—obvious pumping on pads, synths, and bass.\n\n**Hip-Hop / Trap:**\n- **Approach:** Moderate kick-bass sidechaining for low-end clarity. Minimal or no sidechaining on melodic elements unless the beat is heavily electronic.\n- **Settings:** 3:1 to 6:1 ratio, 3-6dB gain reduction on bass, fast attack, moderate release.\n- **Goal:** Kick hits hard and clear without fighting the 808 bass. Upper mix stays stable.\n- **Reference:** Metro Boomin, Travis Scott, Drake—tight low end, but no obvious pumping in the melodic content.\n\n**Rock / Indie:**\n- **Approach:** Subtle or none. Rock mixes traditionally use EQ, panning, and arrangement for separation. Sidechaining is less common and should be transparent if used.\n- **Settings:** If used, 2:1 to 3:1 ratio, 1-3dB gain reduction, gentle settings.\n- **Goal:** Maintain natural dynamics and energy. Sidechaining should solve specific masking issues without altering the genre's organic feel.\n- **Reference:** Foo Fighters, Arctic Monkeys—separation through EQ and arrangement, not obvious ducking.\n\n**Podcast / Voiceover / Film:**\n- **Approach:** Functional and aggressive. Dialogue is always priority one. Background music and ambience must duck clearly when speech is present.\n- **Settings:** 8:1 to ∞:1 ratio, 6-12dB gain reduction, instant attack, moderate release (200-500ms).\n- **Goal:** 100% dialogue intelligibility without listener effort. Ducking is expected and accepted.\n- **Reference:** Professional podcasts (The Daily, Radiolab), film dialogue—music always yields to speech.\n\n**Acoustic / Jazz / Classical:**\n- **Approach:** Minimal or none. These genres prioritize natural dynamics, live performance feel, and organic separation. Sidechaining is rare and should be nearly inaudible if used.\n- **Settings:** If absolutely needed, 1.5:1 to 2:1 ratio, 1-2dB gain reduction, very gentle.\n- **Goal:** Preserve natural performance dynamics. Use traditional mixing techniques (EQ, level balance) instead of heavy processing.\n- **Reference:** Most acoustic and jazz recordings avoid sidechaining entirely.\n\n**Dub / Reggae:**\n- **Approach:** Creative and rhythmic. Sidechaining (especially gate sidechaining and auto-filter sidechaining) is used for dub effects, rhythmic filtering, and space creation.\n- **Settings:** Varies widely—can be subtle or extreme depending on the effect. Often uses gating and filtering instead of compression.\n- **Goal:** Create rhythmic, pulsing textures that are part of the genre's aesthetic.\n- **Reference:** King Tubby, Lee 'Scratch' Perry—heavy use of rhythmic gating and filtering.\n\nKey takeaway: Always reference professional tracks in your genre before applying sidechaining. What's essential in EDM would be inappropriate in jazz. What's subtle in pop would be invisible in house music. Matching genre expectations is as important as technical execution.",
+            "symbolName": "music.quarternote.3",
+            "visualTitle": "Genre-Specific Sidechaining",
+            "visualCaption": "Different genres, different intensity.",
+            "settings": {
+              "Pop": "Transparent, 2-6dB GR, vocal clarity focus",
+              "EDM": "Obvious, 10-15dB+ GR, rhythmic pumping",
+              "Hip-Hop": "Moderate, 3-6dB GR, kick-bass only",
+              "Rock": "Minimal, 1-3dB GR or none, natural dynamics",
+              "Podcast": "Aggressive, 6-12dB GR, dialogue priority"
+            },
+            "proTip": "Create genre-specific compressor presets with appropriate settings for pop, EDM, hip-hop, etc., so you can quickly apply genre-appropriate sidechaining in future projects.",
+            "avoidThis": "Don't apply heavy EDM-style pumping to rock or acoustic genres—it will sound unnatural and out of place. Match your sidechaining intensity to genre conventions.",
+            "checkYourWork": "Your sidechaining matches the intensity and character expected in your genre. If unsure, A/B your mix against professional references.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step16_genre_comparison.png"
+          },
+          {
+            "number": 57,
+            "title": "Automating Sidechain Intensity",
+            "concept": "Automating sidechain parameters across song sections creates dynamic intensity changes—subtle in verses, heavy in choruses—for evolving energy.",
+            "actions": [
+              "Identify sections where sidechain intensity should change (e.g., lighter verse, heavier chorus).",
+              "Automate the compressor's threshold, ratio, or mix control.",
+              "Use snapshots or automation lanes to create smooth transitions.",
+              "Match sidechain intensity to arrangement density and energy."
+            ],
+            "body": "Static sidechain settings throughout an entire song can feel monotonous or inappropriate—verses may need subtle ducking while choruses benefit from heavier pumping. Automating sidechain parameters lets you dynamically adjust intensity to match the song's emotional and arrangement arc.\n\nCommon automation targets:\n\n**Threshold Automation:** Raising the threshold reduces how much the compressor engages (less ducking). Lowering it increases ducking. Automate threshold up during verses for minimal pumping, down during choruses for obvious pumping.\n\n**Ratio Automation:** Lower ratio (2:1 to 4:1) for transparent sections, higher ratio (6:1 to 10:1) for aggressive sections. This changes the intensity of gain reduction without altering when the compressor engages.\n\n**Mix Control Automation (Parallel Sidechaining):** Many compressors offer a 'Mix' or 'Dry/Wet' control that blends the compressed signal with the unprocessed signal. Automate this from 0% (no sidechaining) in quiet sections to 100% (full sidechaining) in heavy sections.\n\n**Attack/Release Automation:** Less common, but you can automate attack/release for changing character—fast attack in verses for tight control, slower attack in choruses for more natural pumping.\n\nWorkflow:\n\n1. Set up your sidechain compression with settings appropriate for the most intense section (usually the chorus or drop).\n\n2. In Logic Pro's automation view, enable automation for the parameter you want to control (threshold, ratio, or mix).\n\n3. Create automation lanes for each section:\n   - Intro: Minimal sidechaining (high threshold or low mix)\n   - Verse: Subtle sidechaining (moderate threshold)\n   - Pre-Chorus: Building intensity (lower threshold)\n   - Chorus: Maximum sidechaining (lowest threshold or highest mix)\n   - Bridge: Variable based on arrangement\n   - Outro: Fade sidechaining intensity to match energy decline\n\n4. Use smooth automation curves (not abrupt steps) to avoid audible jumps. Write gradual transitions that happen over 1-2 bars before section changes.\n\n5. Test the entire song to ensure the sidechain intensity feels musical and supports the arrangement's energy arc.\n\nThis technique is standard in professional pop and EDM production. Choruses often have obvious pumping while verses are clean and stable. This dynamic intensity change reinforces the song's structure and creates evolving energy that keeps listeners engaged.\n\nAdvanced approaches:\n- **Automation Snapshots:** Save different compressor settings as snapshots, then automate switching between them at section boundaries.\n- **Bus-Level Automation:** If using bus-based sidechaining (Step 15), automate the bus compressor's parameters for cohesive intensity changes across all grouped tracks.\n- **Parallel Sidechaining:** Create two buses—one heavily sidechained, one not. Automate the balance between them for smooth intensity transitions.",
+            "symbolName": "slider.horizontal.2.rectangle.and.arrow.triangle.2.circlepath",
+            "visualTitle": "Automating Sidechain Intensity",
+            "visualCaption": "Dynamic ducking that evolves with the song.",
+            "settings": {
+              "Threshold Automation": "High (less ducking) → Low (more ducking)",
+              "Ratio Automation": "2:1 (subtle) → 8:1 (obvious)",
+              "Mix Automation": "0% (off) → 100% (full effect)",
+              "Section-Based": "Verse: subtle, Chorus: heavy"
+            },
+            "proTip": "Automate sidechain intensity to build energy into drops and breakdowns—increase pumping gradually over 8-16 bars leading into a drop for maximum impact.",
+            "avoidThis": "Don't create abrupt, stepped automation changes—sudden shifts in sidechain intensity sound unnatural. Use smooth, gradual curves.",
+            "checkYourWork": "Sidechain intensity changes feel musical and support the song's structure. Verses are stable, choruses have appropriate energy, and transitions are smooth.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step17_automation.png"
+          },
+          {
+            "number": 58,
+            "title": "Parallel Sidechaining: Blending Ducked and Unducked Signals",
+            "concept": "Blending a sidechained version of a track with the unprocessed original creates controlled ducking without losing energy or presence.",
+            "actions": [
+              "Duplicate your target track or route it to a parallel aux.",
+              "Apply aggressive sidechain compression to the duplicate/aux.",
+              "Blend the heavily ducked signal with the dry original for hybrid control.",
+              "Adjust the balance to achieve the desired ducking intensity."
+            ],
+            "body": "Parallel sidechaining is a technique where you blend a heavily sidechained version of a track with the original, unprocessed version. This creates a hybrid sound where you get the clarity and space benefits of sidechaining without completely losing the track's energy and presence. It's especially useful for maintaining low-end power while still allowing kick clarity.\n\nConcept:\n- The original track stays at full volume, maintaining energy and presence.\n- The sidechained duplicate ducks dramatically when the trigger (e.g., kick) plays.\n- Blending the two creates a sound that's 'mostly there' but with subtle ducking—less obvious than pure sidechain compression, but more effective than no sidechaining.\n\nSetup Method 1: Duplicate Track\n\n1. Duplicate your target track (e.g., bass). Name one 'Bass Dry' and one 'Bass SC.'\n\n2. On the 'Bass SC' track, apply aggressive sidechain compression (8:1 ratio, 10-15dB gain reduction, fast attack, tempo-synced release).\n\n3. Leave the 'Bass Dry' track completely unprocessed (no sidechaining).\n\n4. Balance the two tracks by adjusting their faders:\n   - More 'Bass Dry' = more energy, less ducking.\n   - More 'Bass SC' = more obvious ducking, cleaner kick-bass interaction.\n   - Typical balance: 60% dry, 40% sidechained, but adjust to taste.\n\n5. Group the two tracks for easy level control.\n\nSetup Method 2: Aux Send (True Parallel)\n\n1. Keep your bass track at full volume with no sidechaining.\n\n2. Create an auxiliary track. Name it 'Bass SC Parallel.'\n\n3. Insert an aggressive sidechain compressor on the aux, sidechained to your kick.\n\n4. Send your bass track to this aux via a post-fader send.\n\n5. Blend the aux return level to taste—lower for subtle parallel ducking, higher for more obvious effect.\n\nBenefits:\n- **Maintains Energy:** The dry signal keeps the track feeling powerful and present.\n- **Provides Clarity:** The sidechained signal creates space for the kick without sacrificing too much low-end fullness.\n- **Adjustable Intensity:** You can dial in exactly how much ducking you want by adjusting the blend.\n- **Cleaner Than Moderate Settings:** Often cleaner and more musical than trying to find the 'perfect' moderate sidechain settings on a single track.\n\nApplications:\n- **Kick-Bass:** Parallel sidechaining maintains bass power while allowing kick clarity.\n- **Vocal Clarity:** Blend a heavily ducked music bus with a lightly ducked (or undocked) version for subtle vocal space without obvious pumping.\n- **Creative Pumping:** Use extreme sidechaining on the parallel channel for obvious pumping while the dry signal keeps the track grounded.\n\nAdvanced variations:\n- **Multiband Parallel:** Apply heavy low-end sidechaining on the parallel channel while leaving mids/highs dry.\n- **Frequency-Split Parallel:** Duplicate the track, high-pass the dry version (keeping only upper harmonics), low-pass the sidechained version (keeping only the fundamental), then blend. This lets the bass's 'body' stay present while only the fundamental ducks.\n- **NY Compression + Sidechain:** Combine traditional parallel compression (for density) with parallel sidechaining (for space) for hybrid control.",
+            "symbolName": "arrow.triangle.branch",
+            "visualTitle": "Parallel Sidechaining",
+            "visualCaption": "Blend ducked and dry for hybrid control.",
+            "settings": {
+              "Dry Signal": "100% level, no processing",
+              "Sidechained Signal": "Aggressive settings (8:1, 10-15dB GR)",
+              "Typical Blend": "60% dry, 40% sidechained (adjust to taste)",
+              "Method": "Duplicate track or aux send/return"
+            },
+            "proTip": "Use parallel sidechaining when standard sidechain settings feel either too subtle or too aggressive—the blend gives you precise control in the 'middle ground.'",
+            "avoidThis": "Don't add processing (EQ, reverb, etc.) to only one of the parallel signals unless intentional—this can create phase or tonal imbalance. Keep both clean or process identically.",
+            "checkYourWork": "Your track maintains energy and presence while still creating space for the trigger (e.g., kick clarity without losing bass power).",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step18_parallel_sidechain.png"
+          },
+          {
+            "number": 59,
+            "title": "Using Ghost Triggers for Creative Control",
+            "concept": "Creating a silent 'ghost' trigger track—MIDI or audio—gives you complete control over sidechain rhythm without being tied to existing arrangement elements.",
+            "actions": [
+              "Create a new MIDI or audio track that outputs no sound (muted or routed to nowhere).",
+              "Program the exact rhythm you want for sidechain triggering.",
+              "Use this ghost track as the sidechain input for your compressor/gate.",
+              "Adjust the ghost track's rhythm independently of the actual arrangement."
+            ],
+            "body": "Most sidechaining uses existing arrangement elements—kick drum, hi-hat, vocal—as the trigger. But sometimes you want sidechain ducking or gating to follow a rhythm that doesn't exist in your arrangement. Ghost triggers (also called 'phantom' or 'dummy' triggers) solve this by creating a silent track whose sole purpose is to trigger sidechain processing.\n\nApplications:\n\n**Custom Rhythmic Patterns:** Create complex, syncopated pumping rhythms that aren't tied to your kick drum. For example, trigger sidechain ducking on every eighth note, creating a faster pump than the quarter-note kick provides.\n\n**Gate Sidechaining for Vocal Chopping:** Program a MIDI rhythm that 'slices' a sustained vocal into rhythmic fragments, creating stutter and glitch effects.\n\n**Independent Control:** Change the sidechain rhythm without altering the actual kick drum or drum pattern in your mix.\n\n**Pre-Production Experimentation:** Set up ghost triggers early in production to test different pumping rhythms before committing to a drum pattern.\n\nSetup Method 1: MIDI Ghost Trigger\n\n1. Create a new software instrument track in Logic Pro.\n\n2. Load a simple, percussive instrument (like Ultrabeat or a single drum sample in EXS24) or even leave it empty.\n\n3. Mute the track's output: set the track's output to 'No Output' or reduce its fader to -∞.\n\n4. Program a MIDI pattern with the exact rhythm you want for sidechain triggering. For example, quarter-note triggers, sixteenth-note hi-hat patterns, or syncopated rhythms.\n\n5. In your sidechain compressor (on the target track), set the sidechain input to this ghost MIDI track.\n\n6. The compressor will 'hear' the ghost track's rhythm and duck accordingly, even though the ghost track produces no audible sound in the mix.\n\nSetup Method 2: Audio Ghost Trigger\n\n1. Create a new audio track.\n\n2. Route its output to an unused bus (not the Stereo Output) so it produces no audible sound.\n\n3. Place audio regions (like a kick sample) with the desired rhythm.\n\n4. Use this audio track as the sidechain input for your compressor/gate.\n\nBenefits:\n- **Flexibility:** You can edit the ghost track's rhythm independently without affecting the actual arrangement.\n- **Experimentation:** Try different sidechain rhythms instantly by editing the ghost track's MIDI or audio.\n- **Precision:** Create exact, quantized, or custom rhythms that don't depend on live drum performance timing.\n- **Layered Sidechaining:** Use multiple ghost triggers with different rhythms for different sidechain targets (one ghost for kick-style pumping, another for hi-hat-style gating).\n\nAdvanced techniques:\n- **Ghost Velocity Automation:** Program MIDI velocity changes on the ghost track to create dynamic sidechain intensity—louder ghost notes trigger more compression, quieter notes trigger less.\n- **Ghost Track Effects:** Apply effects (reverb, delay) to the ghost trigger (before muting its output) to create 'smeared' or 'trailing' sidechain triggers for experimental effects.\n- **Multiple Ghost Tracks:** Create separate ghost triggers for different sidechain targets—one for kick-style pumping (quarter notes), one for hi-hat gating (sixteenth notes), one for custom rhythmic effects.",
+            "symbolName": "waveform.badge.magnifyingglass",
+            "visualTitle": "Ghost Trigger Control",
+            "visualCaption": "Silent trigger tracks for custom rhythms.",
+            "settings": {
+              "MIDI Ghost": "Software instrument track, output muted or to 'No Output'",
+              "Audio Ghost": "Audio track routed to unused bus (not Stereo Out)",
+              "Rhythm": "Program exact pattern for sidechain triggering",
+              "Use Cases": "Custom pumping, vocal chopping, experimental gating"
+            },
+            "proTip": "Use a simple, short sample (like a single kick or click) on your ghost trigger track for clean, consistent triggering. Avoid complex, sustained sounds which may cause erratic compressor response.",
+            "avoidThis": "Don't forget to mute or re-route the ghost track's output—if it's audible in your mix, it will create unwanted clicks or drum sounds.",
+            "checkYourWork": "Your sidechain processing follows the exact custom rhythm you programmed, independent of the actual arrangement. The ghost track produces no audible sound.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step19_ghost_trigger.png"
+          },
+          {
+            "number": 60,
+            "title": "Final Checklist and Best Practices",
+            "concept": "A final review of sidechaining best practices ensures your implementation is clean, musical, and appropriate for your production goals.",
+            "actions": [
+              "Review all sidechain instances to verify appropriate intensity and settings.",
+              "Check for artifacts: clicks, pumping, distortion, or unnatural movement.",
+              "Test your mix in mono, at low volume, and on multiple playback systems.",
+              "Verify sidechain processing serves the music, not just the technique."
+            ],
+            "body": "Before finalizing your mix, run through this comprehensive sidechaining checklist to ensure professional results:\n\n**1. Verify Signal Routing:**\n- Confirm every sidechain compressor/gate is receiving the correct trigger source.\n- Check that target tracks are being affected (watch the gain-reduction meter).\n- Ensure no accidental routing to Stereo Out or unintended buses.\n\n**2. Check for Artifacts:**\n- Listen for clicks or pops (indicates attack/release too fast).\n- Listen for harsh, unmusical pumping (reduce ratio or raise threshold).\n- Listen for distortion or harshness (reduce gain reduction or change compressor type).\n- Listen for phase issues or hollow sound (check correlation meter, especially in mono).\n\n**3. Test Across Playback Systems:**\n- Check in mono: does the sidechaining translate well or cause problems?\n- Check at low volume: is the ducking still audible and appropriate?\n- Check on earbuds/phone speakers: does the low-end management still work?\n- Check on studio monitors: is the effect too obvious or too subtle?\n\n**4. Verify Musical Appropriateness:**\n- Does the sidechaining support the genre? (Transparent for pop, obvious for EDM, functional for podcasts)\n- Does it support the song's energy arc? (Subtle in verses, heavier in choruses, or consistent throughout?)\n- Does it solve a real problem (masking, clutter, lack of space) or is it arbitrary?\n\n**5. Review Intensity Across All Instances:**\n- If using multiple sidechain compressors, do they all use appropriate settings for their role?\n- Are some elements over-sidechained (losing energy) while others are under-sidechained (still masking)?\n- Is the overall mix stable, or does excessive sidechaining make everything feel pumping and unstable?\n\n**6. Bypass Test:**\n- Bypass all sidechain compressors at once and compare to the sidechained version.\n- The sidechained version should sound clearly better (clearer, more spacious, better separation).\n- If bypassing sounds better, you've over-sidechained—reduce intensity or remove unnecessary instances.\n\n**7. CPU and Session Management:**\n- Verify CPU load is reasonable (bus-based sidechaining helps if CPU is high).\n- Name all sidechain compressors clearly ('SC to Kick,' 'SC to Vocal') for easy troubleshooting.\n- Document your sidechain routing in session notes if the session is complex.\n\n**8. Genre-Specific Final Checks:**\n- **Pop/Rock:** Vocals clear? Low end tight? No obvious pumping in melodic elements?\n- **EDM:** Pumping obvious and musical? Tempo-synced and groovy? Energy maintained?\n- **Hip-Hop:** Kick-bass separation clean? Upper mix stable?\n- **Podcast:** Dialogue 100% intelligible? Background ducks appropriately?\n\n**9. Automation Review:**\n- If using sidechain automation, verify smooth transitions between sections.\n- Ensure automation curves are gradual, not stepped (which causes audible jumps).\n\n**10. Final Reference Check:**\n- A/B your mix against professional references in your genre.\n- Does your sidechaining match the intensity and character of those references?\n\nBest Practices Summary:\n- **Start subtle, add intensity only if needed.** It's easier to add more sidechaining than to undo over-sidechaining.\n- **Use bus-based sidechaining** for CPU efficiency and cohesion in complex sessions.\n- **Match genre expectations.** Don't apply EDM pumping to jazz, or subtle pop sidechaining to house music.\n- **Use dynamic EQ or multiband sidechaining** for transparent, surgical space creation.\n- **Test in mono and at low volume** to verify translation.\n- **Sidechain EQ filtering** improves triggering consistency and reduces artifacts.\n- **Automate sidechain intensity** to match song sections and energy arc.\n- **Reference professional tracks** before finalizing your sidechaining decisions.\n\nSidechaining is one of the most powerful tools in modern mixing and production. When done well, it creates space, clarity, and movement that elevates your mix. When done poorly, it creates pumping, instability, and listener fatigue. Following this checklist ensures you land on the professional side of that divide.",
+            "symbolName": "checkmark.seal.fill",
+            "visualTitle": "Sidechaining Best Practices",
+            "visualCaption": "Final checklist for clean, professional results.",
+            "settings": {
+              "Routing": "Verify all sidechain sources and targets",
+              "Artifacts": "No clicks, harshness, or unnatural pumping",
+              "Translation": "Test mono, low volume, multiple systems",
+              "Musical Fit": "Supports genre, song structure, and energy",
+              "Bypass Test": "Sidechained version clearly better"
+            },
+            "proTip": "Create a 'Sidechain Template' session with pre-configured buses, compressors, and routing for your typical workflow. This speeds up future projects and ensures consistent, professional results.",
+            "avoidThis": "Don't assume your sidechaining is correct without testing—bypass and compare, check in mono, and verify on multiple systems before calling a mix finished.",
+            "checkYourWork": "Your sidechaining is clean, musical, genre-appropriate, and translates well across playback systems. It solves real problems without introducing new ones.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step16_genre_comparison.png"
+          }
+        ]
+      },
+      {
+        "id": "parallel-busses",
+        "title": "Parallel Busses: Advanced Mixing Technique",
+        "series": "Advanced Mixing Series",
+        "summary": "Learn practical parallel routing in Logic Pro for compression, saturation, and time-based effects while preserving transient clarity and musical dynamics.",
+        "duration": "28 min read",
+        "symbolName": "arrow.triangle.branch",
+        "badges": [
+          "Advanced",
+          "Creative",
+          "Technique"
+        ],
+        "isFeatured": true,
+        "checklist": [
+          "Create dedicated parallel aux buses and name them clearly.",
+          "Use pre-fader sends when you need independent blend control.",
+          "Set up parallel compression to add density without flattening transients.",
+          "Use EQ on returns to keep low-end and harshness controlled.",
+          "Level-match and A/B returns against the dry signal.",
+          "Check phase and mono compatibility before finalizing."
+        ],
+        "steps": [
+          {
+            "number": 1,
+            "title": "Understand the Parallel Workflow",
+            "concept": "Parallel processing blends a heavily processed duplicate with the original to gain impact without sacrificing natural tone.",
+            "actions": [
+              "Keep your dry source intact.",
+              "Route a send to a dedicated aux return.",
+              "Blend processed return until it supports the source."
+            ],
+            "body": "This approach lets you use aggressive settings (compression, distortion, filtering) while preserving clarity from the dry path.",
+            "symbolName": "arrow.triangle.branch",
+            "visualTitle": "Dry + Processed Blend",
+            "visualCaption": "Power and control without destroying source detail.",
+            "settings": {
+              "Starting Blend": "10-30% return level",
+              "Signal Flow": "Dry track + aux return"
+            },
+            "proTip": "Set up reusable parallel aux templates for speed across sessions.",
+            "avoidThis": "Do not over-blend returns until the dry source disappears.",
+            "checkYourWork": "Bypassing the return reduces impact, but the mix still sounds natural.",
+            "stepScreenshot": "/assets/training/parallel-busses/step1_concept_diagram.png"
+          },
+          {
+            "number": 2,
+            "title": "Route Parallel Compression",
+            "concept": "Parallel compression adds body and sustain while leaving transient attack intact.",
+            "actions": [
+              "Send drum or vocal bus to an aux with a compressor.",
+              "Use higher ratio and deeper gain reduction than you would in serial mode.",
+              "Blend the return under the dry signal."
+            ],
+            "body": "On drums, this increases perceived power. On vocals, it can improve consistency and intelligibility in dense sections.",
+            "symbolName": "arrow.down.circle.fill",
+            "visualTitle": "Crush Then Blend",
+            "visualCaption": "Aggressive return, subtle mix contribution.",
+            "settings": {
+              "Typical Ratio": "6:1 to 12:1",
+              "Gain Reduction": "8-15 dB on return path"
+            },
+            "proTip": "Shape return tone with EQ after compression to avoid mud.",
+            "avoidThis": "Avoid stacking multiple parallel compressors without purpose.",
+            "checkYourWork": "The return adds energy and sustain without pumping artifacts.",
+            "stepScreenshot": "/assets/training/parallel-busses/step3_drum_compression.png"
+          },
+          {
+            "number": 3,
+            "title": "Use Parallel Reverb and Saturation",
+            "concept": "Parallel time and harmonic effects create size and color while maintaining source focus.",
+            "actions": [
+              "Use separate aux returns for short room, plate, and saturation.",
+              "Filter reverb returns to control low-end wash.",
+              "Automate return levels for transitions and choruses."
+            ],
+            "body": "Parallel reverbs improve depth without clouding the center. Parallel saturation improves perceived loudness and texture.",
+            "symbolName": "sparkles",
+            "visualTitle": "Depth and Harmonics",
+            "visualCaption": "Space and color under the dry signal.",
+            "settings": {
+              "HPF on Reverb Return": "150-300 Hz",
+              "Return Strategy": "Separate aux by effect type"
+            },
+            "proTip": "Short reverbs often read cleaner than long tails in busy arrangements.",
+            "avoidThis": "Do not feed every track into every return bus.",
+            "checkYourWork": "Mix feels wider and richer while lead elements stay clear.",
+            "stepScreenshot": "/assets/training/parallel-busses/step4_reverb_routing.png"
+          },
+          {
+            "number": 4,
+            "title": "Validate Phase and Translation",
+            "concept": "Parallel chains can introduce phase and masking if unchecked.",
+            "actions": [
+              "A/B dry-only vs blend at matched loudness.",
+              "Check mono fold-down for cancellations.",
+              "Trim return timing/phase if low-end weakens."
+            ],
+            "body": "Final checks ensure parallel benefits survive across speakers, headphones, and mono playback.",
+            "symbolName": "checkmark.seal.fill",
+            "visualTitle": "Final Safety Pass",
+            "visualCaption": "Phase-safe, mono-safe, mix-safe.",
+            "settings": {
+              "A/B Method": "Matched loudness comparison",
+              "Mono Check": "No major center collapse"
+            },
+            "proTip": "Keep one reference snapshot with all returns bypassed.",
+            "avoidThis": "Avoid judging return tone in solo for final decisions.",
+            "checkYourWork": "Parallel processing improves excitement and still translates cleanly.",
+            "stepScreenshot": "/assets/training/parallel-busses/step10_complete_workflow.png"
+          }
+        ]
+      },
+      {
+        "id": "stereo-tricks",
+        "title": "Stereo Tricks",
+        "series": "Advanced Mixing Techniques",
+        "summary": "Master professional stereo imaging techniques to create width, depth, and space in your mixes. Learn panning strategies, mid-side processing, the Haas effect, double tracking, and advanced Logic Pro stereo tools for mono-compatible, immersive productions.",
+        "duration": "35 min read",
+        "symbolName": "speaker.wave.3.fill",
+        "badges": [
+          "Advanced",
+          "Professional",
+          "Mixing"
+        ],
+        "isFeatured": true,
+        "checklist": [
+          "Understand the stereo field and placement zones for different instruments.",
+          "Master Logic Pro's pan controls and pan law settings.",
+          "Use the Direction Mixer for precise stereo width control.",
+          "Apply mid-side processing for independent center and side channel shaping.",
+          "Implement the Haas effect correctly for stereo width.",
+          "Record effective double-tracked parts for natural width.",
+          "Create complex stereo delay patterns with Logic's Stereo Delay.",
+          "Monitor phase correlation to ensure mono compatibility.",
+          "Use frequency-dependent stereo processing with Split mode.",
+          "Apply stereo automation for dynamic width changes.",
+          "Avoid common stereo mistakes that cause phase issues.",
+          "Verify mixes in both mono and stereo playback."
+        ],
+        "steps": [
+          {
+            "number": 1,
             "title": "Understanding the Stereo Field",
             "concept": "The stereo field is the perceived horizontal space between left and right speakers where you position sounds in your mix.",
             "actions": [
@@ -12199,7 +13334,7 @@
             "proTip": "Use Direction Mixer's Spread control between 0-100% to narrow overly-wide stereo samples so they fit better in dense mixes, rather than just lowering their volume.",
             "avoidThis": "Don't push Spread above 150% on bass-heavy material—extreme widening at low frequencies causes phase cancellation and weak mono translation.",
             "checkYourWork": "Your stereo sources have the exact width and position you intend, and they maintain clarity and power both in stereo and when checked in mono.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step5_spread_comparison.png"
+            "stepScreenshot": "/assets/training/stereo-tricks/step4_direction_mixer.png"
           },
           {
             "number": 5,
@@ -12599,729 +13734,6 @@
             "proTip": "Automate width on your drum bus to make choruses feel bigger—narrow slightly in verses (90%), widen in choruses (110%)—subtle but effective for creating section contrast.",
             "avoidThis": "Don't automate width on bass frequencies or core elements—width automation works best on pads, atmospheres, background vocals, and supporting elements, not foundation elements.",
             "checkYourWork": "Your width automation creates noticeable energy and contrast between sections, transitions smoothly without artifacts, and maintains mono compatibility at all automation points.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step22_stereo_automation.png"
-          },
-          {
-            "number": 23,
-            "title": "Understanding Sidechaining Fundamentals",
-            "concept": "Sidechaining uses one audio signal to control the behavior of a processor on another track, creating dynamic space and movement in your mix.",
-            "actions": [
-              "Learn the signal flow: source track (trigger) controls processor on target track (affected).",
-              "Understand the difference between transparent mixing sidechaining and creative effect sidechaining.",
-              "Identify which Logic Pro plugins support sidechain input."
-            ],
-            "body": "Sidechaining is a routing technique where one audio signal—the 'trigger' or 'key' signal—controls a processor on a different track. The most common application is sidechain compression, but Logic Pro supports sidechaining with compressors, gates, auto-filters, and several synthesizers.\n\nThe fundamental concept is this: instead of a processor responding to the audio on its own track, it responds to audio from somewhere else. When a kick drum plays, sidechain compression on the bass track 'hears' that kick and compresses the bass at that moment, creating space for the kick to cut through.\n\nThere are two broad philosophical approaches to sidechaining:\n\n**Transparent Sidechaining (Mixing):** The goal is clarity and space without obvious artifacts. You want elements to coexist without frequency masking, but you don't want listeners to consciously notice the ducking. This is common in professional pop, rock, hip-hop, and film mixing. Settings are gentle: low ratios (2:1 to 4:1), moderate attack, release timed to musical phrases.\n\n**Creative Sidechaining (Production):** The ducking effect is deliberate and obvious, often rhythmic and exaggerated. This is the 'pumping' sound in EDM, French house, and modern pop. Settings are aggressive: high ratios (8:1 to ∞:1), fast attack, release synchronized to tempo. The effect becomes part of the arrangement's character.\n\nIn Logic Pro, the following plugins support sidechain input:\n- Compressor (all types including Vintage models)\n- Noise Gate\n- Expander\n- Auto Filter\n- Enveloper\n- EVOC 20 TrackOscillator\n- ES2, Sculpture, and EVOC 20 PolySynth (for synthesis applications)\n\nThird-party plugins like FabFilter Pro-C 2, FabFilter Pro-Q 3 (dynamic EQ), Trackspacer, Soothe 2, and Waves C1 also offer advanced sidechain features, though Logic's stock tools are fully capable for most tasks.\n\nThe sidechaining workflow always follows this pattern:\n1. Place the processor (compressor, gate, etc.) on the track you want to affect (target).\n2. In the processor's interface, locate the Sidechain or 'Side Chain' menu (usually top-right corner).\n3. Select the track or bus you want to use as the trigger source.\n4. Adjust the processor's parameters to achieve your desired response.\n\nSidechaining is one of the most powerful tools in modern mixing and production. It solves frequency masking problems, creates space for vocals and lead elements, automates dynamic changes that would be tedious to write manually, and generates creative rhythmic movement. Understanding when and how to apply it separates amateur mixes from professional ones.",
-            "symbolName": "point.3.filled.connected.trianglepath.dotted",
-            "visualTitle": "Sidechain Signal Flow",
-            "visualCaption": "Source signal controls target processor.",
-            "settings": {
-              "Transparent Settings": "Ratio 2:1-4:1, moderate attack/release",
-              "Creative Settings": "Ratio 8:1+, fast attack, tempo-synced release",
-              "Supported Plugins": "Compressor, Gate, Auto Filter, and more"
-            },
-            "proTip": "When learning sidechaining, start with obvious, exaggerated settings so you can clearly hear what's happening. Once you understand the behavior, dial back the intensity for transparent mixing results.",
-            "avoidThis": "Don't apply sidechaining to every track by default. Use it to solve specific problems or create intentional effects—overuse creates an unstable, pumping mix where nothing feels anchored.",
-            "checkYourWork": "You can explain the signal flow of sidechaining and identify which track is the trigger and which is the target.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step1_sidechain_concept.png"
-          },
-          {
-            "number": 2,
-            "title": "Classic Application: Kick-Bass Ducking",
-            "concept": "Sidechaining bass to kick drum creates low-end clarity by temporarily reducing bass volume when the kick hits, preventing frequency masking in the 40-80Hz range.",
-            "actions": [
-              "Place a compressor on your bass track.",
-              "Set the compressor's sidechain input to your kick drum track.",
-              "Use fast attack (0.1-5ms), moderate ratio (3:1-6:1), and release timed to groove (50-150ms).",
-              "Adjust threshold until you see 3-6dB of gain reduction on each kick hit."
-            ],
-            "body": "The kick drum and bass guitar (or synth bass) both occupy the critical low-frequency range between 40Hz and 80Hz. When both play simultaneously, they compete for the same physical space in speakers and headphones, creating a muddy, undefined low end. This is a fundamental physics problem: a speaker cone can only move in one direction at a time, so overlapping low-frequency signals either reinforce (if perfectly in phase) or cancel each other (if out of phase). More commonly, they simply blur together into indistinct rumble.\n\nSidechain compression solves this by briefly reducing the bass level whenever the kick drum plays, giving the low-end frequency spectrum to the kick during its transient and fundamental tone. As the kick's energy fades, the bass swells back up to fill the space. When done well, the listener doesn't consciously hear ducking—they just hear a tight, punchy low end where kick and bass feel locked together.\n\nHere's the step-by-step setup:\n\n1. Insert Logic's Compressor plugin on your bass track (audio or software instrument).\n\n2. In the compressor interface, locate the 'Side Chain' drop-down menu in the top-right section. Click it and select your kick drum track from the list. If your kick is bussed or part of a drum group, you can select that bus instead.\n\n3. Set the compressor's Attack to 0.1ms to 5ms. You want the compression to engage the instant the kick transient arrives. Fast attack ensures the bass ducks immediately, preventing overlap.\n\n4. Set the Ratio to 3:1 or 4:1 for transparent mixing, or 6:1 to 8:1 if you want more obvious ducking (common in EDM or hip-hop). Higher ratios mean more aggressive volume reduction.\n\n5. Set the Release time based on your track's tempo and groove. For fast dance music (120-128 BPM), try 50ms to 80ms. For slower hip-hop or R&B (80-100 BPM), try 100ms to 150ms. The goal is for the bass to swell back to full volume just as the next kick is about to hit, creating a rhythmic pumping that grooves with the track.\n\n6. Adjust the Threshold until you see the gain-reduction meter showing 3dB to 6dB of reduction on each kick hit. Too much reduction (10dB+) makes the ducking obvious and can kill the bass's energy. Too little (1dB or less) may not solve the masking problem.\n\n7. Leave the Knee at its default (moderate/soft) for most applications. Hard knee creates more obvious compression; soft knee is smoother.\n\n8. Do not add makeup gain on the bass compressor—you're intentionally creating volume reduction here, not trying to make the bass louder overall.\n\n9. Check your mix in mono and at low volume. The kick should feel punchy and defined, and the bass should feel rhythmic and present without fighting the kick.\n\nThis technique is a foundational skill in modern production. It's used on virtually every professional EDM, pop, and hip-hop track. Even rock and metal mixes benefit from subtle kick-bass sidechaining to clean up the low end, though the effect is usually more transparent in those genres.\n\nCommon variations:\n- If your kick has a long tail or sub-bass that extends beyond the transient, adjust the release to match that decay.\n- If the ducking feels too obvious, reduce the ratio or increase the threshold (which reduces how much the compressor engages).\n- For electronic music with perfectly quantized, four-on-the-floor kicks, you can use a volume shaper plugin like LFO Tool or Cableguys ShaperBox instead of a compressor. These let you literally draw the volume curve, avoiding compression artifacts entirely.",
-            "symbolName": "waveform.path",
-            "visualTitle": "Kick-Bass Ducking Setup",
-            "visualCaption": "Bass ducks when kick hits.",
-            "settings": {
-              "Attack": "0.1-5ms (instant response)",
-              "Release": "50-150ms (tempo/groove dependent)",
-              "Ratio": "3:1 to 6:1 (transparent to obvious)",
-              "Gain Reduction Target": "3-6dB per kick hit"
-            },
-            "proTip": "Set your compressor's release time by playing the track and adjusting the knob until the gain-reduction meter 'breathes' with the rhythm—bouncing down and recovering in sync with the groove.",
-            "avoidThis": "Don't set threshold so low that the compressor is always compressing, even when the kick isn't playing. The bass should return to full volume between kicks.",
-            "checkYourWork": "Your kick drum is punchy and clear, the bass has rhythmic movement, and the low end sounds tight in both stereo and mono playback.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step2_kick_bass_compressor.png"
-          },
-          {
-            "number": 3,
-            "title": "Visual Analysis: Kick-Bass Interaction",
-            "concept": "Understanding the waveform and frequency interaction between kick and bass helps you visualize what sidechaining accomplishes.",
-            "actions": [
-              "Use a spectrum analyzer to see frequency overlap between kick and bass.",
-              "Observe the gain-reduction meter on the bass compressor to verify ducking timing.",
-              "Compare the waveform before and after sidechain compression to see the volume reduction."
-            ],
-            "body": "Visual feedback is essential for dialing in effective kick-bass sidechaining. Logic Pro's built-in metering, along with the Channel EQ's analyzer and third-party spectrum analyzers, help you see what's happening in the frequency spectrum.\n\nBefore sidechaining, place Logic's Channel EQ on both the kick and bass tracks (set to Analyzer mode without making EQ changes). Play the section where kick and bass play together. You'll see both tracks' energy concentrated in the 40-80Hz range, with peaks likely overlapping. This overlap is where masking occurs—both sounds are fighting for the same frequency space.\n\nAfter setting up sidechain compression, watch the gain-reduction meter on the bass compressor. You should see the meter respond rhythmically, showing 3-6dB of reduction each time the kick hits, then releasing back to zero before the next kick. If the meter shows constant compression (never fully releasing), your threshold is too low. If it barely moves, your threshold is too high or your ratio is too gentle.\n\nIn the Arrange window, you can visually compare the bass waveform before and after sidechaining by duplicating the bass track, applying sidechain compression to one, and bouncing both to audio for side-by-side comparison. The sidechained version will show distinct 'dips' in amplitude aligned with each kick hit.\n\nSome producers use oscilloscope plugins (like s(M)exoscope or Youlean Loudness Meter's waveform view) to see the actual waveform interaction in real-time. When kick and bass are properly sidechained, you'll see the bass waveform 'duck' or reduce in amplitude precisely when the kick waveform appears.\n\nThis visual approach is especially helpful when learning sidechaining. Once you develop an ear for it, you'll rely more on listening, but visual confirmation speeds up the learning process and helps troubleshoot problems like incorrect release timing or insufficient gain reduction.",
-            "symbolName": "chart.xyaxis.line",
-            "visualTitle": "Frequency Spectrum Analysis",
-            "visualCaption": "See the overlap and the solution.",
-            "settings": {
-              "Key Frequency Range": "40-80Hz (kick/bass fundamental)",
-              "Visual Tools": "Channel EQ analyzer, gain-reduction meter, spectrum analyzer",
-              "Metering Goal": "3-6dB GR on kick hits, full release between"
-            },
-            "proTip": "Use Logic's 'Split by Channel' feature on a stereo analyzer to compare kick and bass frequencies side-by-side, making overlap immediately obvious.",
-            "avoidThis": "Don't rely solely on visual metering—always use your ears to verify that the ducking feels musical and grooves with the track.",
-            "checkYourWork": "You can see the frequency overlap before sidechaining and observe the gain-reduction meter responding rhythmically after sidechaining.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step3_spectrum_analysis.png"
-          },
-          {
-            "number": 4,
-            "title": "Vocal Clarity: Music Bus Sidechaining",
-            "concept": "Routing melodic instruments through a sidechain-compressed bus triggered by vocals creates transparent space for lyrics without obvious ducking.",
-            "actions": [
-              "Create an auxiliary track and route guitars, keys, pads, and backing vocals to it.",
-              "Insert a compressor on the aux track and set its sidechain input to the lead vocal.",
-              "Use gentle settings: 3:1 to 4:1 ratio, 5-10ms attack, 80-150ms release.",
-              "Target 1-3dB of gain reduction during vocal phrases."
-            ],
-            "body": "One of the most powerful but under-discussed applications of sidechaining is creating space for lead vocals by gently compressing the entire musical bed when the vocal is present. This technique is standard in professional pop, rock, and hip-hop mixing, but it's so transparent that most listeners never consciously notice it.\n\nThe problem: when a dense arrangement plays—full band with guitars, keys, pads, synths, backing vocals—the lead vocal can get masked, especially in the 1kHz to 3kHz range where vocal intelligibility lives. You could boost the vocal with EQ or simply turn it up, but this often makes it feel disconnected from the track. Instead, subtly reducing everything else when the vocal is present makes the vocal feel embedded in the mix while remaining clear.\n\nHere's the setup:\n\n1. Create a new auxiliary (bus) track. Name it something like 'Music Bus' or 'Sidechain Aux.'\n\n2. Route all melodic and harmonic tracks to this aux. This typically includes: electric guitars, acoustic guitars, keyboards, synths, pads, strings, backing vocals, and any other mid-range-heavy elements. Do NOT route drums, bass, or lead vocals to this bus—those stay independent.\n\n3. Insert Logic's Compressor on the Music Bus aux track.\n\n4. In the compressor, set the Side Chain input to your lead vocal track.\n\n5. Configure the compressor with these settings:\n   - Ratio: 3:1 to 4:1 (gentle, transparent)\n   - Attack: 5ms to 10ms (fast enough to respond to vocal transients, but not so fast that it creates artifacts)\n   - Release: 80ms to 150ms (should recover between vocal phrases, not during sustained notes)\n   - Knee: Soft (for smooth, gradual compression)\n   - Threshold: adjust until you see 1dB to 3dB of gain reduction when the vocal is singing. During instrumental breaks (no vocal), the compressor should show zero gain reduction.\n\n6. Do not add makeup gain—you want the music to genuinely get quieter when the vocal is present.\n\n7. Solo the vocal and the music bus together, then play a dense section (like a chorus with full instrumentation). You should hear the music subtly 'breathe' around the vocal—ducking slightly when the vocal is loud, swelling back up during rests and between words.\n\nThe beauty of this technique is its transparency. If done correctly, the listener doesn't hear 'pumping' or obvious volume changes—they simply hear a vocal that's clear and present without sounding disconnected. The vocal feels 'in the pocket' of the mix.\n\nThis method is far superior to traditional automation for several reasons:\n- It's automatic: the compressor responds to every vocal phrase without manual rides.\n- It's consistent: every time that vocal phrase plays, the same amount of ducking happens.\n- It's frequency-neutral: unlike EQ, which changes tone, this simply creates dynamic space.\n\nCommon variations:\n- If the ducking is too obvious, reduce the ratio to 2:1 or raise the threshold so less compression happens.\n- If the vocal still isn't cutting through, check if your release time is too fast (causing the music to swell back up too quickly) or if your attack is too slow (letting initial consonants get masked).\n- For more surgical control, use dynamic EQ sidechaining (covered in Step 7) to target only the 1-3kHz vocal range instead of compressing the entire music bus.",
-            "symbolName": "music.note.list",
-            "visualTitle": "Music Bus Method",
-            "visualCaption": "Melodic elements duck for vocal clarity.",
-            "settings": {
-              "Ratio": "3:1 to 4:1",
-              "Attack": "5-10ms",
-              "Release": "80-150ms",
-              "Gain Reduction": "1-3dB during vocal phrases"
-            },
-            "proTip": "If your mix has both a verse and a chorus vocal, use the loudest vocal section (usually the chorus) to set your threshold. The compressor will naturally compress less during quieter verse vocals, creating dynamic variation.",
-            "avoidThis": "Don't route drums or bass to the music bus—sidechaining these creates an unstable, pumping low end. Keep the rhythm section independent.",
-            "checkYourWork": "Your lead vocal is consistently clear and intelligible without sounding louder or disconnected from the track. The music subtly breathes around the vocal.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step4_music_bus_routing.png"
-          },
-          {
-            "number": 5,
-            "title": "Podcast and Voiceover Ducking",
-            "concept": "Sidechaining background music to dialogue tracks ensures spoken words remain intelligible while maintaining atmospheric support.",
-            "actions": [
-              "Place a compressor on your background music or sound effects track.",
-              "Set the sidechain input to your dialogue or voiceover track.",
-              "Use aggressive settings for instant, obvious ducking: 8:1 ratio, <1ms attack, 200-500ms release.",
-              "Target 6-12dB of gain reduction to guarantee dialogue clarity."
-            ],
-            "body": "In podcasts, audiobooks, video production, and film mixing, dialogue clarity is paramount. Listeners need to understand every word without straining, even if background music or ambient sound effects are present. Sidechain compression automates this balance, ensuring music ducks the moment someone speaks and returns when they stop.\n\nUnlike musical sidechaining (which is often subtle), podcast/voiceover ducking is usually obvious and aggressive. The goal is not transparency—it's absolute dialogue priority. Listeners expect background elements to reduce in volume when speech is present, and this ducking is considered standard, professional behavior.\n\nSetup for podcast/voiceover ducking:\n\n1. Arrange your session with dialogue/voiceover on one track and background music/ambience on a separate track (or aux bus if you have multiple background elements).\n\n2. Insert a compressor on the background music track.\n\n3. Set the compressor's sidechain input to the dialogue track.\n\n4. Configure aggressive settings:\n   - Ratio: 8:1 to ∞:1 (limiter-style, for strong ducking)\n   - Attack: 0.1ms to 1ms (instant response to speech)\n   - Release: 200ms to 500ms (should swell back up during natural pauses, not during mid-sentence breaths)\n   - Threshold: adjust until you see 6dB to 12dB of gain reduction whenever dialogue is present. This ensures the background drops significantly, leaving room for speech.\n\n5. Test by playing sections with continuous dialogue. The background music should drop to roughly 25-40% of its normal volume, making dialogue effortlessly clear. During silent sections (no dialogue), the music should return to full volume.\n\n6. Pay special attention to the release time. If it's too fast (under 100ms), the music will pump up and down during natural speech rhythm, sounding unnatural. If it's too slow (over 1 second), the music won't return to full volume during intentional pauses or between speakers, making those pauses feel awkward.\n\nThis technique is so common in podcast production that many podcast-specific tools (like iZotope RX's Dialogue Isolate or dedicated podcast mixing plugins) include preset 'music ducking' modes that essentially automate this exact sidechain compression setup.\n\nFor video production (YouTube, corporate videos, e-learning), this same technique is used to duck background music under narration. Some video editors even automate this in post-production software (Premiere Pro, Final Cut Pro) using built-in audio ducking features, but doing it in Logic Pro during audio post-production gives you more precise control over the compression character.\n\nVariations:\n- For multi-speaker podcasts, route all dialogue tracks to a dialogue bus, then use that bus as the sidechain source. This way, background music ducks when any speaker talks.\n- For audiobooks, you might want less aggressive ducking (4:1 ratio, 3-6dB GR) if the background music is meant to remain present but supportive.\n- For film mixing, you may need to sidechain multiple background layers (music, ambience, effects) separately to the dialogue, giving you granular control over how much each element ducks.",
-            "symbolName": "mic.fill",
-            "visualTitle": "Dialogue Ducking",
-            "visualCaption": "Speech always clear over background.",
-            "settings": {
-              "Ratio": "8:1 to ∞:1",
-              "Attack": "0.1-1ms",
-              "Release": "200-500ms",
-              "Gain Reduction": "6-12dB during dialogue"
-            },
-            "proTip": "Add a high-pass filter to the sidechain input (covered in Step 11) to prevent low-frequency rumble or plosives from triggering the compressor—only mid-range speech frequencies should trigger ducking.",
-            "avoidThis": "Don't use slow attack times (over 10ms) for dialogue ducking—the first syllable of each word may get masked before the compressor engages.",
-            "checkYourWork": "Every word of dialogue is effortlessly clear, and background music feels present during pauses but never competes with speech.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step5_podcast_ducking.png"
-          },
-          {
-            "number": 6,
-            "title": "Reverb Sidechaining for Vocal Clarity",
-            "concept": "Sidechaining vocal reverb to the dry vocal prevents long, washy tails from obscuring lyrics while maintaining a sense of space.",
-            "actions": [
-              "Create a reverb send/return for vocals (aux track with reverb plugin).",
-              "Insert a compressor after the reverb on the aux return.",
-              "Set the compressor's sidechain input to the dry vocal track.",
-              "Use moderate settings: 4:1 ratio, 5-10ms attack, 50-150ms release, targeting 3-6dB GR."
-            ],
-            "body": "Reverb is essential for placing vocals in a believable acoustic space, but long reverb tails can smear lyrics and reduce intelligibility, especially in dense mixes. The traditional solution is to shorten the reverb decay time, but this sacrifices the lush, immersive quality that makes reverb effective. Sidechain compression on the reverb return offers a better solution: let the reverb ring freely during pauses and sustained notes, but duck it when new lyrics arrive.\n\nThis technique is widely used in modern pop, worship music, and ballad production. It allows for dramatic, long-decay reverbs that don't cloud fast lyrical passages.\n\nSetup:\n\n1. Create a standard reverb send/return setup: insert a Send on your lead vocal track, routing it to an auxiliary track. On that aux, insert a reverb plugin (Space Designer, ChromaVerb, or your preferred reverb).\n\n2. After the reverb plugin on the aux return, insert Logic's Compressor.\n\n3. Set the compressor's sidechain input to the dry lead vocal track (not the aux—you want the compressor to 'hear' the original vocal, not the reverb).\n\n4. Configure the compressor:\n   - Ratio: 4:1 to 6:1 (moderate, musical compression)\n   - Attack: 5ms to 10ms (fast enough to respond to new lyrics, slow enough to avoid clicks)\n   - Release: 50ms to 150ms (should release during sustained notes, not instantly)\n   - Threshold: adjust until you see 3dB to 6dB of gain reduction when the vocal is singing. The reverb should duck noticeably, but not disappear.\n\n5. Solo the vocal and reverb aux together. As the vocal sings, the reverb should reduce in level, creating space for the dry vocal. When the vocal sustains a note or pauses, the reverb should swell back up, filling the space with ambience.\n\n6. The result: you can use a 2.5-second reverb decay (which would normally blur fast lyrics) because it's being ducked when the vocal is active and only fully audible during gaps.\n\nThis technique transforms how you approach reverb in dense mixes. You're no longer limited to short, safe decay times—you can use long, lush reverbs that automatically get out of the way when needed.\n\nVariations:\n- For even more surgical control, use a dynamic EQ (like FabFilter Pro-Q 3 or Waves F6) on the reverb return, sidechained to the vocal, targeting only the 1-3kHz midrange. This ducks the 'body' of the reverb without affecting the highs or lows, preserving shimmer and depth.\n- For duet vocals, route both vocalists to the same reverb aux, then sidechain that reverb to a bus containing both vocal tracks. The reverb will duck when either singer is active.\n- If the ducking sounds too obvious, reduce the ratio to 3:1 or increase the release time so the reverb recovers more gently.",
-            "symbolName": "sparkles",
-            "visualTitle": "Reverb Sidechaining",
-            "visualCaption": "Lush reverb that doesn't smear lyrics.",
-            "settings": {
-              "Ratio": "4:1 to 6:1",
-              "Attack": "5-10ms",
-              "Release": "50-150ms",
-              "Gain Reduction": "3-6dB when vocal is active"
-            },
-            "proTip": "Use a longer release time (150ms+) for ballads and slow songs where you want the reverb to feel 'always there.' Use shorter release (50ms) for fast, rhythmic vocal passages.",
-            "avoidThis": "Don't apply this technique to every reverb in your mix—only reverbs on lead elements where clarity matters. Background vocal reverbs, for example, can usually stay untouched.",
-            "checkYourWork": "Your vocal reverb feels spacious and dramatic, but lyrics remain clear even during fast, dense passages. The reverb is most noticeable during pauses and sustained notes.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step6_reverb_sidechain.png"
-          },
-          {
-            "number": 7,
-            "title": "Delay Sidechaining for Clean Repeats",
-            "concept": "Sidechaining delay returns to the dry source prevents delay repeats from cluttering the mix during continuous performance.",
-            "actions": [
-              "Set up a delay send/return on an aux track.",
-              "Insert a compressor after the delay plugin on the aux.",
-              "Sidechain the compressor to the dry source track.",
-              "Use settings similar to reverb sidechaining: 4:1, 5ms attack, 50-150ms release."
-            ],
-            "body": "Delay effects add depth, space, and interest, but long delay tails or multiple repeats can clutter a mix, especially when the source instrument or vocal is playing continuously. Sidechaining the delay return creates a clean, professional sound where delay is audible during gaps but doesn't compete with the dry signal.\n\nThis technique is particularly useful for:\n- Vocal delays where you want distinct echoes at the end of phrases but not during active singing.\n- Guitar delays in dense rock or pop mixes.\n- Dub-style delay throws where the effect is dramatic but shouldn't mask the original performance.\n\nSetup (identical structure to reverb sidechaining):\n\n1. Create a delay send/return: insert a Send on your source track (vocal, guitar, etc.), routing to an auxiliary track. On the aux, insert a delay plugin (Delay Designer, Stereo Delay, Tape Delay, or Echo).\n\n2. After the delay plugin on the aux, insert Logic's Compressor.\n\n3. Set the compressor's sidechain input to the dry source track.\n\n4. Configure the compressor:\n   - Ratio: 4:1 to 6:1\n   - Attack: 5ms to 10ms\n   - Release: 50ms to 150ms (adjust based on delay time—longer delay times may benefit from longer release)\n   - Threshold: adjust until you see 3-6dB of gain reduction when the source is playing. The delay should duck but remain subtly audible.\n\n5. Test with a phrase that has distinct gaps. The delay repeats should be clearly audible during pauses but should sit behind the dry signal when the source is active.\n\n6. For dramatic delay throws (common in EDM, dub, and reggae), increase the ratio to 8:1 or higher so the delay almost disappears when the source plays, then swells up dramatically during gaps.\n\nThis technique is especially powerful for quarter-note or eighth-note delay settings where repeats would otherwise stack up and create rhythmic clutter. With sidechaining, you get the rhythmic interest of timed delays without the mud.\n\nVariations:\n- For ping-pong or stereo delays, apply the sidechain compression after the delay plugin but before any stereo imaging. This keeps the delay's spatial character intact while still ducking its overall level.\n- For feedback-heavy delays (where repeats go on for many cycles), sidechaining prevents the buildup from becoming overpowering.\n- For delay throws on specific words or phrases, consider automating the delay send level instead of relying on sidechaining—this gives you more surgical control over which words get delayed.",
-            "symbolName": "arrow.forward.circle",
-            "visualTitle": "Delay Sidechain Setup",
-            "visualCaption": "Clean repeats during gaps, subtle during performance.",
-            "settings": {
-              "Ratio": "4:1 to 6:1 (or 8:1+ for dramatic ducking)",
-              "Attack": "5-10ms",
-              "Release": "50-150ms",
-              "Gain Reduction": "3-6dB when source is active"
-            },
-            "proTip": "Match the compressor's release time to your delay time for musical interaction. For a quarter-note delay at 120 BPM (500ms delay), try a 200-300ms release so the delay swells back up just before the next repeat.",
-            "avoidThis": "Don't sidechain delay on every track—use it selectively where the delay would otherwise clutter the mix. Simple, short delays often don't need sidechaining.",
-            "checkYourWork": "Delay repeats are distinct and clear during pauses, but don't compete with or muddy the dry source when it's playing.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step7_delay_sidechain.png"
-          },
-          {
-            "number": 8,
-            "title": "Creative Pumping: EDM and Electronic Music",
-            "concept": "Aggressive sidechain compression with exaggerated settings creates the signature 'pumping' effect in electronic dance music.",
-            "actions": [
-              "Sidechain melodic elements (synths, pads, bass, leads) to the kick drum.",
-              "Use extreme settings: 8:1 to ∞:1 ratio, 0.1ms attack, tempo-synced release.",
-              "Target heavy gain reduction: 6-12dB or more for obvious pumping.",
-              "Experiment with release curves and timing for rhythmic character."
-            ],
-            "body": "In electronic dance music—especially house, techno, trance, and future bass—sidechain compression isn't just a mixing tool; it's a core production element. The exaggerated 'pumping' or 'breathing' effect where the entire mix rhythmically ducks around the kick drum is a deliberate aesthetic choice that creates energy, movement, and dancefloor impact.\n\nThis technique became famous in French house (Daft Punk, Justice) and is now ubiquitous in mainstream EDM. The pumping is obvious and intentional—listeners expect it and associate it with the genre.\n\nSetup for creative pumping:\n\n1. Identify which elements should pump. Typically: bass, synth pads, lead synths, plucks, and melodic elements. Drums (other than kick), vocals, and high-end percussion often stay independent for clarity.\n\n2. You can either:\n   - Place a sidechain compressor on each individual track (more control, more CPU).\n   - Route all pumping elements to a single aux bus and compress that bus (easier, more cohesive pumping).\n\n3. For individual tracks or the pumping bus, insert a compressor and set the sidechain input to your kick drum.\n\n4. Configure aggressive settings:\n   - Ratio: 8:1 to ∞:1 (limiter-style compression for maximum pumping)\n   - Attack: 0.1ms to 1ms (instant response to kick transient)\n   - Release: Tempo-synced to your track's BPM. For four-on-the-floor kicks, try setting release so the compressor fully recovers just before the next kick hit. Many compressors offer a 'Note' or 'Sync' release mode—set it to 1/4 note or 1/8 note depending on your kick pattern.\n   - Threshold: adjust until you see 10-15dB of gain reduction on each kick. You want obvious, heavy pumping.\n\n5. Listen to the groove. The pumping should feel rhythmic and musical, not arbitrary. If the release is too fast, the pump will feel abrupt and disconnected. If it's too slow, the elements won't recover before the next kick, creating a constant squashed feeling.\n\n6. The result: every time the kick hits, the entire musical bed ducks dramatically, then swells back up, creating a rhythmic 'breathing' that drives the energy of the track.\n\nMany producers use dedicated sidechain tools instead of traditional compressors for this application:\n- **Volume Shapers** (like Cableguys VolumeShaper or LFO Tool): These let you literally draw the volume envelope, giving you total control over the pump curve. You can create sharp, aggressive ducks or smooth, gentle swells.\n- **Nicky Romero Kickstart**: A plugin designed specifically for EDM-style pumping, with presets and tempo-sync features.\n- **Xfer Records LFO Tool**: Industry-standard for precise control over pumping curves.\n\nThese tools avoid compression artifacts (distortion, tone shift) because they're simply controlling volume, not actually compressing the signal. This can result in cleaner, more controlled pumping.\n\nCreative variations:\n- Pump only specific frequency ranges using multiband sidechain (covered in Step 9). For example, pump the mids and lows but leave the high-end shimmer untouched.\n- Use different release times on different elements: pump pads slowly and heavily, but pump bass quickly for a tighter feel.\n- Automate the sidechain intensity: heavy pumping during buildups and drops, lighter pumping during verses.",
-            "symbolName": "waveform.and.magnifyingglass",
-            "visualTitle": "EDM Pumping Effect",
-            "visualCaption": "Obvious, rhythmic ducking for energy.",
-            "settings": {
-              "Ratio": "8:1 to ∞:1",
-              "Attack": "0.1-1ms",
-              "Release": "Tempo-synced (1/4 or 1/8 note)",
-              "Gain Reduction": "10-15dB or more"
-            },
-            "proTip": "For the cleanest, most controlled pumping, use a volume shaper plugin instead of a compressor—you'll avoid compression artifacts and get precise control over the envelope shape.",
-            "avoidThis": "Don't pump everything including drums (other than kick) and vocals—keep some elements stable so the mix doesn't feel chaotic and unstable.",
-            "checkYourWork": "The pumping is obvious, rhythmic, and musical. It drives the energy of the track and feels locked to the groove, not arbitrary or random.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step8_edm_pumping.png"
-          },
-          {
-            "number": 9,
-            "title": "Dynamic EQ Sidechaining: Surgical Frequency Control",
-            "concept": "Sidechain-triggered dynamic EQ ducks only specific frequency ranges instead of entire tracks, creating transparent space without obvious volume changes.",
-            "actions": [
-              "Use a dynamic EQ plugin (FabFilter Pro-Q 3, Waves F6, or Logic's built-in multiband compressor as a workaround).",
-              "Set the sidechain input to the triggering track (e.g., vocal).",
-              "Target the frequency range where masking occurs (e.g., 1-3kHz for vocal clarity).",
-              "Apply moderate reduction: 2-4dB in the targeted frequency range."
-            ],
-            "body": "Traditional sidechain compression reduces the overall volume of a track, which can feel heavy-handed and obvious. Dynamic EQ sidechaining is a more surgical approach: it only reduces specific frequency ranges where masking occurs, leaving the rest of the track untouched. This creates transparent space without the 'pumping' artifacts of full-range sidechain compression.\n\nFor example, if your lead vocal is being masked by guitars in the 2-3kHz range, you don't need to compress the entire guitar track—you only need to reduce that specific frequency band when the vocal is present. The guitars' low end, high-end sparkle, and overall punch remain intact. This is the approach modern mix engineers use for professional pop and rock productions.\n\nSetup using FabFilter Pro-Q 3 (the industry-standard dynamic EQ with sidechain):\n\n1. Insert Pro-Q 3 on the track that needs frequency space reduction (e.g., rhythm guitars, pads, or a music bus).\n\n2. Enable a dynamic EQ band by clicking a band point and setting its type to 'Dynamic' (the lightning bolt icon).\n\n3. Set the band's frequency to the range where masking occurs. For vocal clarity, try 1.5-3kHz. For kick-bass separation, try 60-100Hz.\n\n4. Set the band's Q (width) to moderate—not too narrow (which sounds surgical and obvious) but not too wide (which affects too much frequency range). Start with Q around 2-4.\n\n5. In Pro-Q 3's sidechain section (bottom of the interface), set the external sidechain input to your triggering track (e.g., lead vocal).\n\n6. Adjust the dynamic band's threshold and range. Threshold determines how loud the trigger signal must be before reduction happens. Range determines how much reduction is applied (typically 2-4dB for transparency, up to 6-8dB for more obvious ducking).\n\n7. The result: when the vocal sings, the guitars' 2-3kHz range ducks by 3dB, creating space for vocal intelligibility. But the guitars' low-end body and high-end sparkle remain unchanged. The listener hears clear vocals without noticing any compression or pumping.\n\nFor Logic Pro users without third-party dynamic EQ:\n- Use Logic's Multipressor as a workaround: split the frequency spectrum into bands, then use external sidechain on the band(s) you want to duck. This is less elegant than Pro-Q 3 but effective.\n- Alternatively, use Trackspacer (a dedicated sidechain dynamic EQ plugin) which automatically analyzes the trigger signal and carves out space in the target track.\n- Or use standard sidechain compression with a sidechain EQ filter (covered in Step 11) to make the compressor only 'hear' specific frequencies. This is less precise than true dynamic EQ but can work for simple cases.\n\nDynamic EQ sidechaining is particularly useful for:\n- Vocal clarity in dense pop/rock mixes.\n- Podcast/voiceover where you want to duck music's midrange without affecting bass and treble.\n- Kick-bass separation where you want to duck the bass's 60-80Hz fundamental without affecting its upper harmonics.\n- Reducing sibilance clashes between lead and backing vocals (duck the backing vocals' 6-8kHz range when the lead vocal is present).",
-            "symbolName": "waveform.path.ecg",
-            "visualTitle": "Dynamic EQ Sidechain",
-            "visualCaption": "Target frequencies, not entire tracks.",
-            "settings": {
-              "Common Ranges": "Vocals: 1.5-3kHz, Kick-Bass: 60-100Hz, Sibilance: 6-8kHz",
-              "Reduction Amount": "2-4dB for transparency, 6-8dB for obvious space",
-              "Q (Width)": "2-4 (moderate, musical)",
-              "Tools": "FabFilter Pro-Q 3, Waves F6, Trackspacer, iZotope Neutron"
-            },
-            "proTip": "Use Pro-Q 3's real-time analyzer to visually identify exactly which frequency range is causing masking, then place your dynamic EQ band right on that peak.",
-            "avoidThis": "Don't use overly narrow Q values (10+) which create surgical, obvious dips. Dynamic EQ should be felt, not heard.",
-            "checkYourWork": "Your lead element (vocal, kick, etc.) is clear and present, but the overall tonal balance of supporting tracks remains unchanged. The space creation is transparent.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step9_dynamic_eq.png"
-          },
-          {
-            "number": 10,
-            "title": "Multiband Sidechain Compression",
-            "concept": "Splitting audio into frequency bands and sidechaining only specific bands preserves tonal balance while creating targeted dynamic space.",
-            "actions": [
-              "Use Logic's Multipressor or a third-party multiband compressor.",
-              "Split the frequency spectrum (e.g., Low: <200Hz, Mid: 200-5kHz, High: >5kHz).",
-              "Enable external sidechain on the band(s) you want to duck (typically Low or Mid).",
-              "Leave other bands untouched or use gentle settings."
-            ],
-            "body": "Multiband sidechain compression combines the best aspects of full-range sidechain and dynamic EQ: it splits audio into multiple frequency bands, then applies sidechain compression only to the bands where you need it. This is more flexible than standard sidechain (which affects everything) and easier to set up than dynamic EQ (which requires precision frequency selection).\n\nCommon applications:\n\n**Low-End Ducking:** Sidechain only the low band (<150Hz) of a bass track to the kick, leaving the bass's midrange and harmonic content untouched. This creates kick-bass separation without losing the 'warmth' and 'body' of the bass tone.\n\n**Vocal Clarity:** Sidechain only the midrange band (1-4kHz) of a music bus to the vocal, leaving lows and highs intact. This creates vocal space without affecting the bass or high-frequency shimmer.\n\n**Podcast/VO Ducking:** Sidechain the midrange band of background music to dialogue, leaving the music's bass and treble at full volume. This maintains musical richness while ensuring speech clarity.\n\nSetup in Logic Pro using Multipressor:\n\n1. Insert Logic's Multipressor on the target track (the one that should be affected).\n\n2. Set up your crossover points to split the frequency spectrum. For kick-bass example: Low band up to 150Hz, Mid band 150Hz to 5kHz, High band above 5kHz.\n\n3. For each band you want to sidechain, click the band's settings and enable the external sidechain input. Set it to your trigger track (e.g., kick drum).\n\n4. Configure the compression settings for each sidechained band:\n   - Low band (for kick-bass): Ratio 4:1-6:1, fast attack (0.1ms), moderate release (80-150ms), threshold for 3-6dB GR.\n   - Mid band (for vocal clarity): Ratio 3:1-4:1, 5-10ms attack, 100-200ms release, threshold for 2-4dB GR.\n\n5. Leave bands you don't want to duck either bypassed or set to very gentle settings.\n\n6. The result: you get targeted frequency-specific ducking without affecting the entire tonal balance of the track.\n\nThird-party multiband compressors with better sidechain features:\n- **FabFilter Pro-MB**: Offers up to 6 bands with individual sidechain inputs, per-band attack/release, and excellent visual feedback.\n- **Waves C6**: Industry-standard multiband with sidechain on each band.\n- **iZotope Ozone Dynamics**: Multiband mode with sidechain, often used for mastering-style multiband ducking.\n\nMultiband sidechaining is especially powerful when:\n- You want the benefits of dynamic EQ sidechaining but don't want to invest in FabFilter Pro-Q 3.\n- You need different ducking behavior in different frequency ranges (e.g., aggressive ducking in the lows, gentle ducking in the mids, no ducking in the highs).\n- You're working with complex, full-bandwidth sources (like synth pads or guitar buses) where simple full-range compression would be too heavy-handed.",
-            "symbolName": "square.split.diagonal",
-            "visualTitle": "Multiband Sidechain",
-            "visualCaption": "Frequency-specific ducking with tonal preservation.",
-            "settings": {
-              "Low Band": "<150Hz (kick-bass separation)",
-              "Mid Band": "150Hz-5kHz (vocal clarity)",
-              "High Band": ">5kHz (usually left alone)",
-              "Tools": "Logic Multipressor, FabFilter Pro-MB, Waves C6"
-            },
-            "proTip": "Use multiband sidechain on synth pads and atmospheric elements—duck only the mids for vocal space while leaving the lush low-end sub and high-end shimmer untouched.",
-            "avoidThis": "Don't sidechain all bands equally—that's just standard sidechain with extra CPU load. Use multiband specifically to target problem frequency ranges.",
-            "checkYourWork": "You've created space in the critical frequency range (e.g., low end for kick, mids for vocal) without altering the overall tonal character of the track.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step10_multiband_sidechain.png"
-          },
-          {
-            "number": 11,
-            "title": "Sidechain EQ Filtering for Targeted Triggering",
-            "concept": "Using the sidechain input's built-in EQ filter makes the compressor respond only to specific frequencies, creating more musical and transparent results.",
-            "actions": [
-              "In your sidechain compressor, locate the 'Filter' or 'Side Chain EQ' section.",
-              "Enable filtering and choose a filter type (high-pass, low-pass, or bandpass).",
-              "Set the filter frequency to isolate the trigger signal's most relevant range.",
-              "Test and adjust—the compressor should now respond only to filtered frequencies."
-            ],
-            "body": "By default, when you set up sidechain compression, the compressor 'listens' to the full frequency spectrum of the trigger track. But often, only certain frequencies are relevant. For kick-bass ducking, you only care about the kick's low-frequency thump (40-100Hz), not its high-frequency click. For vocal sidechaining, you only care about the vocal's intelligibility range (1-4kHz), not its breath noise or sibilance.\n\nLogic Pro's Compressor includes a built-in 'Side Chain' filter section that lets you EQ the sidechain input, making the compressor respond only to the frequencies you choose. This creates more musical, transparent compression with fewer artifacts.\n\nCommon filter applications:\n\n**High-Pass Filter (HPF):** Makes the compressor ignore low frequencies. Use this when sidechaining to vocals or dialogue to prevent plosives, breath noise, and low-frequency rumble from triggering compression. Set the HPF to 80-150Hz so the compressor only 'hears' the actual speech/vocal tone.\n\n**Low-Pass Filter (LPF):** Makes the compressor ignore high frequencies. Use this when sidechaining bass to kick—set an LPF around 120-200Hz so the compressor only responds to the kick's fundamental thump, not its beater click or cymbal bleed.\n\n**Bandpass Filter (BPF):** Makes the compressor only 'hear' a specific frequency range. Use this for surgical applications: for example, set a bandpass around 2-3kHz when sidechaining a music bus to vocals, so the compressor only responds to the core vocal intelligibility range.\n\n**Parametric EQ:** Some compressors (including Logic's) offer a parametric bell filter in the sidechain. Use this to emphasize a specific frequency that should trigger compression more strongly. For example, boost 60Hz in the sidechain when compressing bass to kick, making the compressor extra-sensitive to the kick's fundamental.\n\nSetup in Logic Pro's Compressor:\n\n1. Set up your sidechain compression as usual (compressor on target track, sidechain input set to trigger track).\n\n2. In the Compressor interface, locate the 'Side Chain' section (usually collapsed—click the disclosure triangle to expand it).\n\n3. Enable the 'Filter' checkbox.\n\n4. Choose your filter type from the drop-down: LP (low-pass), BP (bandpass), HP (high-pass), ParEQ (parametric), or HS (high shelf).\n\n5. Adjust the filter frequency and Q (width) to target your desired range. For example:\n   - Kick-bass with LPF: Set frequency to 150Hz so only low-end triggers compression.\n   - Vocal clarity with BPF: Set center frequency to 2.5kHz, Q around 1.5, so only vocal presence range triggers compression.\n   - Dialogue ducking with HPF: Set frequency to 100Hz to ignore rumble and plosives.\n\n6. Listen and adjust. The compressor's behavior will change—it should now respond more musically and predictably because it's only 'hearing' the relevant frequencies.\n\nThis technique is incredibly powerful but often overlooked. It can transform overly aggressive sidechain compression into smooth, musical ducking simply by making the compressor ignore irrelevant frequency content.\n\nThird-party compressors often have even more sophisticated sidechain filtering:\n- **FabFilter Pro-C 2:** Includes a built-in sidechain EQ with full parametric controls and real-time spectrum analysis.\n- **Waves Renaissance Compressor:** Offers sidechain high-pass and low-pass filters.\n- **SSL Native Bus Compressor:** Includes the famous SSL sidechain filter controls (SC HPF).",
-            "symbolName": "slider.vertical.3",
-            "visualTitle": "Sidechain Filter Control",
-            "visualCaption": "Make compressor respond only to relevant frequencies.",
-            "settings": {
-              "HPF (vocal/dialogue)": "80-150Hz (ignore rumble)",
-              "LPF (kick-bass)": "120-200Hz (only thump triggers)",
-              "BPF (vocal clarity)": "2-3kHz center (presence range)",
-              "ParEQ": "Boost or cut to emphasize specific triggers"
-            },
-            "proTip": "Use FabFilter Pro-C 2's sidechain audition feature (headphone icon) to solo what the compressor is 'hearing'—this makes dialing in the perfect filter setting instant and obvious.",
-            "avoidThis": "Don't use extremely narrow bandpass filters (Q > 10) unless you have a very specific reason—this can make the compressor respond inconsistently as the trigger track's frequency content varies.",
-            "checkYourWork": "Your sidechain compression responds smoothly and predictably, with fewer false triggers and more musical ducking that follows the most important elements of the trigger signal.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step11_sidechain_filter.png"
-          },
-          {
-            "number": 12,
-            "title": "Gate Sidechaining for Rhythmic Effects",
-            "concept": "Using a sidechain-triggered gate creates rhythmic chopping, stuttering, and on/off effects synchronized to a trigger track.",
-            "actions": [
-              "Insert Logic's Noise Gate on the track you want to rhythmically chop.",
-              "Set the gate's sidechain input to a rhythmic trigger (kick, hi-hat, or dedicated trigger track).",
-              "Use fast attack (0.1ms), adjust threshold for full gating, and set hold/release for desired effect length.",
-              "Create dramatic rhythmic effects synchronized to another element."
-            ],
-            "body": "While most sidechaining discussions focus on compression (which reduces volume), gate sidechaining is equally powerful for creative production. A noise gate silences audio when the trigger signal is below a threshold—when sidechained, this means the target track only plays when the trigger is present. This creates rhythmic chopping, stuttering, and gating effects that are perfectly locked to another element's rhythm.\n\nCommon creative applications:\n\n**Rhythmic Pad Gating:** Sidechain a lush pad or string sound to a kick or hi-hat pattern. The pad will only play when the trigger hits, creating a rhythmic, pulsing texture instead of a sustained drone. This is common in trance, techno, and progressive house.\n\n**Vocal Chopping:** Sidechain a vocal sample to a rhythmic MIDI trigger track (silent, used only for triggering). Create a MIDI pattern with the rhythm you want, then use it to 'slice' the vocal into rhythmic fragments.\n\n**Bass Gating:** Sidechain a sustained bass note to a kick or hi-hat. The bass will play in sync with the drums, creating a staccato, rhythmic bass line from what was originally a long sustained note.\n\n**Reverse Ducking (Creative Effect):** Use a gate sidechained to kick to make a synth or pad *only* play when the kick hits, creating a pumping effect that's the opposite of standard sidechain compression.\n\nSetup:\n\n1. Insert Logic's Noise Gate on the track you want to rhythmically chop (target).\n\n2. Set the gate's 'Side Chain' input to your trigger track (kick, hi-hat, or a dedicated MIDI trigger track).\n\n3. Configure the gate:\n   - Threshold: Set high enough that the target track is fully gated (silent) when the trigger is not present. You'll need to adjust by ear—start around -20dB and increase until you hear complete silence between triggers.\n   - Attack: Set to fastest (0.1ms) for instant gating, or slower (10-50ms) for a fade-in effect on each gate opening.\n   - Hold: Determines how long the gate stays open after the trigger stops. For short, staccato effects, use 10-50ms. For longer, more sustained gates, use 100-300ms.\n   - Release: How quickly the gate closes (fades out) after the hold time. Fast release (10-50ms) creates abrupt cuts. Slower release (100-300ms) creates smooth fade-outs.\n\n4. Test different trigger sources:\n   - Sidechain to kick for four-on-the-floor rhythmic gating.\n   - Sidechain to hi-hats for faster, more intricate rhythmic patterns.\n   - Sidechain to a custom MIDI trigger track for complete rhythmic control.\n\n5. Experiment with attack/hold/release to shape the character of the gating. Short settings create stuttering, glitchy effects. Long settings create smooth, pulsing textures.\n\nAdvanced techniques:\n- Use the gate's 'Hysteresis' control (if available) to prevent flutter when the trigger signal is near the threshold.\n- Combine gate sidechaining with volume automation for hybrid effects: gate for rhythmic structure, automation for musical phrasing.\n- Use a multiband gate (or split your signal into bands and gate each separately) for frequency-specific rhythmic gating—for example, gate only the midrange of a pad while leaving bass and treble sustained.\n\nGate sidechaining is less common in traditional mixing but extremely popular in electronic production, sound design, and remix work. It's a fast way to create complex rhythmic patterns from static, sustained sounds.\n\nThird-party gate plugins with advanced sidechain features:\n- **FabFilter Pro-G:** Industry-standard gate with sidechain input, per-band gating, and visual metering.\n- **Waves Renaissance DeEsser/Gate:** Classic gate with sidechain.\n- **Logic's own Enveloper:** While not technically a gate, it can be sidechained and used for similar rhythmic effects.",
-            "symbolName": "bolt.horizontal.circle",
-            "visualTitle": "Rhythmic Gate Sidechain",
-            "visualCaption": "Chop and slice in sync with triggers.",
-            "settings": {
-              "Attack": "0.1ms (instant) or 10-50ms (fade-in)",
-              "Hold": "10-50ms (staccato) or 100-300ms (sustained)",
-              "Release": "10-50ms (abrupt) or 100-300ms (smooth)",
-              "Threshold": "Adjust for complete gating"
-            },
-            "proTip": "Create a dedicated MIDI trigger track with no sound output—just MIDI notes—then use it to sidechain-gate any audio track. This gives you complete rhythmic control without being tied to existing drum patterns.",
-            "avoidThis": "Don't use gate sidechaining on lead vocals or primary melodic elements in traditional mixes—it's too destructive. Reserve it for creative production and sound design.",
-            "checkYourWork": "Your target track plays only when the trigger is active, creating a tight, rhythmic effect that's perfectly locked to the groove. The gating is clean without clicks or artifacts.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step12_gate_sidechain.png"
-          },
-          {
-            "number": 13,
-            "title": "Creative Auto-Filter Sidechaining",
-            "concept": "Sidechain-triggered auto-filters create dynamic tone changes synchronized to other tracks, useful for rhythmic filtering and movement.",
-            "actions": [
-              "Insert Logic's Auto Filter on the track you want to affect.",
-              "Set the filter type (low-pass, high-pass, or bandpass) and configure cutoff/resonance.",
-              "Enable sidechain input and select your trigger track.",
-              "Adjust envelope controls to shape how the filter responds to the trigger."
-            ],
-            "body": "Beyond compression and gating, Logic Pro's Auto Filter plugin supports sidechain input, allowing filter cutoff to be modulated by external audio sources. This creates dynamic, rhythmic filtering effects where a track's tone changes in response to another element—common in electronic music, dub, and creative sound design.\n\nApplications:\n\n**Rhythmic Low-Pass Filtering:** Sidechain a synth pad's Auto Filter to the kick. The pad's brightness increases when the kick hits, then dulls between kicks, creating rhythmic movement.\n\n**Dub-Style High-Pass Sweeps:** Sidechain a bass or guitar's Auto Filter to a hi-hat or shaker. The filter opens and closes rhythmically, creating classic dub/reggae filtering effects.\n\n**Dynamic Vocal Effects:** Sidechain a doubled vocal or harmony's Auto Filter to the lead vocal. The doubled vocal's tone shifts when the lead sings, creating space and movement.\n\nSetup:\n\n1. Insert Logic's Auto Filter on your target track.\n\n2. Choose a filter type:\n   - Low-Pass (LP): Typical for rhythmic brightness changes.\n   - High-Pass (HP): Useful for creating 'thinning' effects synchronized to triggers.\n   - Band-Pass (BP): For more dramatic, sweeping tonal shifts.\n\n3. Set the cutoff frequency and resonance to taste. Higher resonance creates more pronounced filter 'sweep' character.\n\n4. Enable the Auto Filter's external sidechain input and select your trigger track.\n\n5. Adjust the envelope and dynamics controls:\n   - Attack: How quickly the filter opens when triggered.\n   - Release: How quickly the filter closes after the trigger stops.\n   - Amount: How much the filter cutoff moves (the range of the sweep).\n\n6. The result: when your trigger plays, the filter cutoff moves, changing the target track's tone in sync with the trigger's rhythm.\n\nThis technique is less common in traditional mixing but extremely powerful for:\n- Creating movement and interest in static, sustained sounds (pads, drones).\n- Adding rhythmic complexity without additional instruments.\n- Dub production and remix work where filter sweeps are a core aesthetic element.\n\nAdvanced variations:\n- Combine auto-filter sidechaining with standard sidechain compression for hybrid effects: the track ducks in volume *and* tone simultaneously.\n- Use automation to change the filter's cutoff frequency over time while the sidechain controls the dynamic movement.\n- Route multiple tracks through a bus with a sidechain auto-filter for cohesive, ensemble filtering effects.",
-            "symbolName": "waveform.path.badge.minus",
-            "visualTitle": "Auto-Filter Sidechain",
-            "visualCaption": "Dynamic tone changes synchronized to triggers.",
-            "settings": {
-              "Filter Type": "Low-Pass (brighten/dull), High-Pass (thin/full), Band-Pass (sweeps)",
-              "Cutoff & Resonance": "Set base tone character",
-              "Sidechain Amount": "Controls depth of filter modulation",
-              "Envelope": "Attack/Release shape the filter movement"
-            },
-            "proTip": "Use subtle auto-filter sidechaining on background vocals or doubled instruments to create space for lead elements without obvious volume ducking—the tonal shift is often less noticeable than compression.",
-            "avoidThis": "Don't apply heavy resonance with fast sidechain triggering—this can create harsh, whistling artifacts. Keep resonance moderate for musical results.",
-            "checkYourWork": "Your target track's tone changes rhythmically in sync with the trigger, creating movement and interest without artifacts or harshness.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step13_autofilter_sidechain.png"
-          },
-          {
-            "number": 14,
-            "title": "Troubleshooting Common Sidechaining Problems",
-            "concept": "Understanding common artifacts and issues—pumping, clicks, inconsistent triggering, and over-compression—helps you achieve clean, professional results.",
-            "actions": [
-              "Identify audible artifacts: clicks, pumping, distortion, or loss of energy.",
-              "Check attack/release times: too fast causes clicks, too slow causes sluggish response.",
-              "Verify threshold and ratio: ensure gain reduction is appropriate for the task.",
-              "Use sidechain filtering or dynamic EQ to prevent false triggers."
-            ],
-            "body": "Even with proper setup, sidechain compression can introduce unwanted artifacts or fail to work as intended. Here are the most common problems and their solutions:\n\n**Problem 1: Audible Clicking or Popping**\n- Cause: Attack time is too fast (especially <1ms) or release is too fast with high gain reduction.\n- Solution: Increase attack to 3-10ms for smoother envelope response. Increase release to at least 50ms. Use soft knee for gentler compression onset.\n\n**Problem 2: Obvious, Unmusical Pumping**\n- Cause: Too much gain reduction (10dB+), or release time is out of sync with the track's rhythm.\n- Solution: Reduce ratio (from 8:1 down to 4:1), raise threshold to reduce gain reduction, or adjust release time so the compressor recovers musically (try tempo-synced release). For transparent mixing, aim for 2-6dB GR, not 10dB+.\n\n**Problem 3: Inconsistent or Weak Triggering**\n- Cause: Trigger signal is too quiet, or sidechain filtering is removing the relevant frequencies.\n- Solution: Check that your trigger track (e.g., kick) is actually loud enough to cross the threshold. Disable sidechain filtering temporarily to verify. If the trigger is a drum bus with multiple elements, consider using just the isolated kick for cleaner triggering.\n\n**Problem 4: Compressor Always Compressing (No Recovery)**\n- Cause: Threshold is set too low, or release is too long.\n- Solution: Raise the threshold so the compressor only engages when the trigger actually plays. Shorten release time so the compressor recovers between triggers. Check the gain-reduction meter—it should return to zero between triggers.\n\n**Problem 5: Loss of Energy or 'Dead' Sound**\n- Cause: Too much compression, or you've sidechained too many elements simultaneously.\n- Solution: Reduce the number of sidechained tracks—keep some elements stable for mix energy. Use multiband or dynamic EQ sidechaining instead of full-range compression to preserve tonal balance. Check makeup gain—though typically not needed for sidechaining, extremely heavy compression may benefit from a small amount to restore perceived loudness.\n\n**Problem 6: Distortion or Harsh Artifacts**\n- Cause: Over-compression with high ratio and low threshold, or compressor topology mismatch (some compressors add color/saturation that clashes with the source).\n- Solution: Switch compressor types—use a clean VCA or digital compressor instead of a colored Opto or FET model. Reduce ratio and increase threshold. Use multiband sidechaining to avoid compressing already-distorted frequency ranges.\n\n**Problem 7: Sidechain Not Working At All**\n- Cause: Sidechain routing is incorrect, or plugin doesn't support external sidechain.\n- Solution: Verify the sidechain input is actually set to your trigger track (check the 'Side Chain' menu in the compressor). Ensure the trigger track contains audio and isn't muted or soloed in a way that bypasses the sidechain send. Verify the compressor plugin supports external sidechain (Logic's stock Compressor does; some third-party plugins may not).\n\n**Problem 8: Phase Cancellation or Hollow Sound**\n- Cause: When using parallel or bus-based sidechaining, the sidechained element and non-sidechained elements may be out of phase, especially in the low end.\n- Solution: Use Logic's Gain Utility plugin to flip phase on one of the elements. Check correlation metering. Avoid heavy sidechain compression on low-end elements if phase issues persist—use dynamic EQ or multiband instead.\n\nGeneral troubleshooting workflow:\n1. Bypass the sidechain compressor and compare. If the 'improved' version sounds worse, reduce the intensity or rethink the approach.\n2. Solo the affected track and listen for artifacts (clicks, pumping, distortion) without the rest of the mix.\n3. Check the gain-reduction meter—it should respond rhythmically and predictably. If it's erratic or constantly pinned, your settings need adjustment.\n4. Test in mono. Sidechaining issues (especially phase problems) often become more obvious in mono playback.\n5. Take a break. Ear fatigue makes artifacts harder to identify. Fresh ears catch problems quickly.",
-            "symbolName": "wrench.and.screwdriver",
-            "visualTitle": "Troubleshooting Guide",
-            "visualCaption": "Identify and fix common artifacts.",
-            "settings": {
-              "Clicks": "Increase attack/release, use soft knee",
-              "Pumping": "Reduce ratio, raise threshold, adjust release timing",
-              "Weak Triggering": "Check trigger level, disable sidechain filter",
-              "Always Compressing": "Raise threshold, shorten release",
-              "Distortion": "Lower ratio, switch compressor type"
-            },
-            "proTip": "Create a 'test session' with a simple kick and bass to dial in your preferred sidechain settings. Save these as compressor presets you can recall in future projects.",
-            "avoidThis": "Don't keep adding more compression or stacking multiple sidechain compressors to 'fix' problems—often the solution is less compression, better settings, or a different approach (like dynamic EQ).",
-            "checkYourWork": "Your sidechain compression is transparent and musical (for mixing) or intentionally obvious (for creative effects), with no audible clicks, distortion, or unnatural pumping.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step14_troubleshooting.png"
-          },
-          {
-            "number": 15,
-            "title": "Advanced Workflow: Bus-Based Sidechaining",
-            "concept": "Routing multiple tracks to buses for cohesive sidechain behavior reduces CPU load and creates unified ducking across track groups.",
-            "actions": [
-              "Group related tracks (synths, guitars, pads) onto a bus.",
-              "Apply sidechain compression to the bus instead of individual tracks.",
-              "Use separate buses for different instrument families with unique sidechain needs.",
-              "Reduce CPU load while maintaining consistent, musical ducking."
-            ],
-            "body": "When mixing complex sessions with many tracks, applying individual sidechain compressors to each track is inefficient and can create inconsistent ducking where different elements pump at different rates. Bus-based sidechaining solves this by grouping related tracks onto auxiliary buses and applying a single sidechain compressor to each bus. This creates cohesive, unified ducking and significantly reduces CPU load.\n\nCommon bus groupings for sidechaining:\n\n**Melodic Bus:** Route all synths, keys, pads, and melodic instruments to one aux. Sidechain this bus to the lead vocal for transparent vocal clarity across all melodic content.\n\n**Rhythm Bus (non-kick/bass):** Route percussion, hi-hats, shakers, and rhythm elements to one aux. Sidechain to kick for EDM-style pumping that affects rhythmic layers but not the bass.\n\n**Background Vocal Bus:** Route all backing vocals and harmonies to one aux. Sidechain to lead vocal for automatic space creation without affecting individual backing vocal levels.\n\n**Pad Bus:** Route all atmospheric pads, strings, and ambient textures to one aux. Sidechain to drums or vocal for breathing space in dense sections.\n\nSetup workflow:\n\n1. Identify which tracks have similar sidechaining needs (same trigger source, similar compression settings).\n\n2. Create an auxiliary track for the group. Name it descriptively (e.g., 'Melodic Bus - SC').\n\n3. Route all relevant tracks to this aux by setting their output to the aux bus.\n\n4. Insert a compressor on the aux track and configure sidechain input and settings as usual.\n\n5. The entire group now ducks together, creating cohesive movement. If one synth needs different ducking, split it to a separate bus with unique settings.\n\nBenefits:\n- **CPU Efficiency:** One compressor instance instead of five or ten.\n- **Cohesion:** All elements in the bus duck together, creating unified movement rather than individual pumping.\n- **Mix Glue:** Bus-based sidechaining naturally groups elements sonically, helping them feel like they belong together.\n- **Easier Automation:** You can automate the bus's sidechain intensity (via threshold or ratio) to create dynamic changes (e.g., heavy pumping in the chorus, light pumping in the verse) without touching individual tracks.\n\nAdvanced variations:\n- Use **multiple buses** with different sidechain settings: a 'Heavy SC Bus' for tracks that should pump obviously, and a 'Light SC Bus' for tracks that need subtle ducking.\n- **Parallel sidechain processing:** Route tracks to both a sidechained bus and a non-sidechained bus, then blend them for hybrid ducking intensity.\n- **Nested buses:** Create a master 'Music Bus' with moderate sidechaining, then create sub-buses (guitars, keys, pads) with individual sidechain settings. This gives you both broad and surgical control.\n\nThis approach is standard in professional pop, EDM, and film mixing. It's how engineers manage complex sessions with dozens of tracks while maintaining CPU efficiency and mix cohesion.",
-            "symbolName": "point.3.filled.connected.trianglepath.dotted",
-            "visualTitle": "Bus-Based Sidechaining",
-            "visualCaption": "Group tracks for cohesive ducking.",
-            "settings": {
-              "Melodic Bus": "All synths/keys/melodic → sidechain to vocal",
-              "Rhythm Bus": "All perc (non-kick) → sidechain to kick",
-              "Pad Bus": "All pads/strings → sidechain to drums/vocal",
-              "BG Vocal Bus": "All backing vocals → sidechain to lead vocal"
-            },
-            "proTip": "Create color-coded track labels for sidechained buses so you can quickly identify which elements are being affected at a glance in large sessions.",
-            "avoidThis": "Don't route your entire mix (including drums and bass) to a single sidechained bus—this creates unstable, pumping mixes. Only route elements that genuinely need ducking.",
-            "checkYourWork": "Related tracks duck together as a cohesive group, creating unified movement. CPU load is reduced compared to individual track-by-track sidechaining.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step15_bus_routing.png"
-          },
-          {
-            "number": 16,
-            "title": "Sidechaining in Different Genres",
-            "concept": "Different musical genres have distinct sidechaining conventions—understanding genre expectations helps you apply appropriate techniques.",
-            "actions": [
-              "Identify genre-specific sidechaining norms (transparent for pop/rock, obvious for EDM, functional for podcasts).",
-              "Adjust intensity based on genre: subtle for acoustic/jazz, moderate for pop/hip-hop, extreme for EDM.",
-              "Study reference tracks in your genre to understand sidechaining conventions.",
-              "Balance technical needs (clarity) with creative expectations (pumping)."
-            ],
-            "body": "Sidechaining is not one-size-fits-all. Each genre has different conventions, expectations, and intensity levels. Understanding these norms helps you apply sidechaining appropriately and avoid genre-inappropriate choices.\n\n**Pop Music:**\n- **Approach:** Transparent to moderate. Sidechaining is used for vocal clarity (music bus method) and subtle low-end management (kick-bass ducking).\n- **Settings:** 2:1 to 4:1 ratio, 2-6dB gain reduction, moderate attack/release.\n- **Goal:** Vocals clear and upfront, low end tight, but no obvious pumping. Listeners shouldn't consciously notice the ducking.\n- **Reference:** Taylor Swift, The Weeknd, Ariana Grande—vocals are effortlessly clear without sounding disconnected.\n\n**EDM / Electronic Dance Music (House, Trance, Techno, Future Bass):**\n- **Approach:** Obvious and aggressive. Sidechaining is a production element, not just a mix tool. Heavy pumping creates energy and movement.\n- **Settings:** 8:1 to ∞:1 ratio, 10-15dB+ gain reduction, fast attack (0.1ms), tempo-synced release.\n- **Goal:** Dramatic, rhythmic pumping that grooves with the kick. The effect is intentional and central to the genre's sound.\n- **Reference:** Daft Punk ('One More Time'), Deadmau5, Calvin Harris—obvious pumping on pads, synths, and bass.\n\n**Hip-Hop / Trap:**\n- **Approach:** Moderate kick-bass sidechaining for low-end clarity. Minimal or no sidechaining on melodic elements unless the beat is heavily electronic.\n- **Settings:** 3:1 to 6:1 ratio, 3-6dB gain reduction on bass, fast attack, moderate release.\n- **Goal:** Kick hits hard and clear without fighting the 808 bass. Upper mix stays stable.\n- **Reference:** Metro Boomin, Travis Scott, Drake—tight low end, but no obvious pumping in the melodic content.\n\n**Rock / Indie:**\n- **Approach:** Subtle or none. Rock mixes traditionally use EQ, panning, and arrangement for separation. Sidechaining is less common and should be transparent if used.\n- **Settings:** If used, 2:1 to 3:1 ratio, 1-3dB gain reduction, gentle settings.\n- **Goal:** Maintain natural dynamics and energy. Sidechaining should solve specific masking issues without altering the genre's organic feel.\n- **Reference:** Foo Fighters, Arctic Monkeys—separation through EQ and arrangement, not obvious ducking.\n\n**Podcast / Voiceover / Film:**\n- **Approach:** Functional and aggressive. Dialogue is always priority one. Background music and ambience must duck clearly when speech is present.\n- **Settings:** 8:1 to ∞:1 ratio, 6-12dB gain reduction, instant attack, moderate release (200-500ms).\n- **Goal:** 100% dialogue intelligibility without listener effort. Ducking is expected and accepted.\n- **Reference:** Professional podcasts (The Daily, Radiolab), film dialogue—music always yields to speech.\n\n**Acoustic / Jazz / Classical:**\n- **Approach:** Minimal or none. These genres prioritize natural dynamics, live performance feel, and organic separation. Sidechaining is rare and should be nearly inaudible if used.\n- **Settings:** If absolutely needed, 1.5:1 to 2:1 ratio, 1-2dB gain reduction, very gentle.\n- **Goal:** Preserve natural performance dynamics. Use traditional mixing techniques (EQ, level balance) instead of heavy processing.\n- **Reference:** Most acoustic and jazz recordings avoid sidechaining entirely.\n\n**Dub / Reggae:**\n- **Approach:** Creative and rhythmic. Sidechaining (especially gate sidechaining and auto-filter sidechaining) is used for dub effects, rhythmic filtering, and space creation.\n- **Settings:** Varies widely—can be subtle or extreme depending on the effect. Often uses gating and filtering instead of compression.\n- **Goal:** Create rhythmic, pulsing textures that are part of the genre's aesthetic.\n- **Reference:** King Tubby, Lee 'Scratch' Perry—heavy use of rhythmic gating and filtering.\n\nKey takeaway: Always reference professional tracks in your genre before applying sidechaining. What's essential in EDM would be inappropriate in jazz. What's subtle in pop would be invisible in house music. Matching genre expectations is as important as technical execution.",
-            "symbolName": "music.quarternote.3",
-            "visualTitle": "Genre-Specific Sidechaining",
-            "visualCaption": "Different genres, different intensity.",
-            "settings": {
-              "Pop": "Transparent, 2-6dB GR, vocal clarity focus",
-              "EDM": "Obvious, 10-15dB+ GR, rhythmic pumping",
-              "Hip-Hop": "Moderate, 3-6dB GR, kick-bass only",
-              "Rock": "Minimal, 1-3dB GR or none, natural dynamics",
-              "Podcast": "Aggressive, 6-12dB GR, dialogue priority"
-            },
-            "proTip": "Create genre-specific compressor presets with appropriate settings for pop, EDM, hip-hop, etc., so you can quickly apply genre-appropriate sidechaining in future projects.",
-            "avoidThis": "Don't apply heavy EDM-style pumping to rock or acoustic genres—it will sound unnatural and out of place. Match your sidechaining intensity to genre conventions.",
-            "checkYourWork": "Your sidechaining matches the intensity and character expected in your genre. If unsure, A/B your mix against professional references.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step16_genre_comparison.png"
-          },
-          {
-            "number": 17,
-            "title": "Automating Sidechain Intensity",
-            "concept": "Automating sidechain parameters across song sections creates dynamic intensity changes—subtle in verses, heavy in choruses—for evolving energy.",
-            "actions": [
-              "Identify sections where sidechain intensity should change (e.g., lighter verse, heavier chorus).",
-              "Automate the compressor's threshold, ratio, or mix control.",
-              "Use snapshots or automation lanes to create smooth transitions.",
-              "Match sidechain intensity to arrangement density and energy."
-            ],
-            "body": "Static sidechain settings throughout an entire song can feel monotonous or inappropriate—verses may need subtle ducking while choruses benefit from heavier pumping. Automating sidechain parameters lets you dynamically adjust intensity to match the song's emotional and arrangement arc.\n\nCommon automation targets:\n\n**Threshold Automation:** Raising the threshold reduces how much the compressor engages (less ducking). Lowering it increases ducking. Automate threshold up during verses for minimal pumping, down during choruses for obvious pumping.\n\n**Ratio Automation:** Lower ratio (2:1 to 4:1) for transparent sections, higher ratio (6:1 to 10:1) for aggressive sections. This changes the intensity of gain reduction without altering when the compressor engages.\n\n**Mix Control Automation (Parallel Sidechaining):** Many compressors offer a 'Mix' or 'Dry/Wet' control that blends the compressed signal with the unprocessed signal. Automate this from 0% (no sidechaining) in quiet sections to 100% (full sidechaining) in heavy sections.\n\n**Attack/Release Automation:** Less common, but you can automate attack/release for changing character—fast attack in verses for tight control, slower attack in choruses for more natural pumping.\n\nWorkflow:\n\n1. Set up your sidechain compression with settings appropriate for the most intense section (usually the chorus or drop).\n\n2. In Logic Pro's automation view, enable automation for the parameter you want to control (threshold, ratio, or mix).\n\n3. Create automation lanes for each section:\n   - Intro: Minimal sidechaining (high threshold or low mix)\n   - Verse: Subtle sidechaining (moderate threshold)\n   - Pre-Chorus: Building intensity (lower threshold)\n   - Chorus: Maximum sidechaining (lowest threshold or highest mix)\n   - Bridge: Variable based on arrangement\n   - Outro: Fade sidechaining intensity to match energy decline\n\n4. Use smooth automation curves (not abrupt steps) to avoid audible jumps. Write gradual transitions that happen over 1-2 bars before section changes.\n\n5. Test the entire song to ensure the sidechain intensity feels musical and supports the arrangement's energy arc.\n\nThis technique is standard in professional pop and EDM production. Choruses often have obvious pumping while verses are clean and stable. This dynamic intensity change reinforces the song's structure and creates evolving energy that keeps listeners engaged.\n\nAdvanced approaches:\n- **Automation Snapshots:** Save different compressor settings as snapshots, then automate switching between them at section boundaries.\n- **Bus-Level Automation:** If using bus-based sidechaining (Step 15), automate the bus compressor's parameters for cohesive intensity changes across all grouped tracks.\n- **Parallel Sidechaining:** Create two buses—one heavily sidechained, one not. Automate the balance between them for smooth intensity transitions.",
-            "symbolName": "slider.horizontal.2.rectangle.and.arrow.triangle.2.circlepath",
-            "visualTitle": "Automating Sidechain Intensity",
-            "visualCaption": "Dynamic ducking that evolves with the song.",
-            "settings": {
-              "Threshold Automation": "High (less ducking) → Low (more ducking)",
-              "Ratio Automation": "2:1 (subtle) → 8:1 (obvious)",
-              "Mix Automation": "0% (off) → 100% (full effect)",
-              "Section-Based": "Verse: subtle, Chorus: heavy"
-            },
-            "proTip": "Automate sidechain intensity to build energy into drops and breakdowns—increase pumping gradually over 8-16 bars leading into a drop for maximum impact.",
-            "avoidThis": "Don't create abrupt, stepped automation changes—sudden shifts in sidechain intensity sound unnatural. Use smooth, gradual curves.",
-            "checkYourWork": "Sidechain intensity changes feel musical and support the song's structure. Verses are stable, choruses have appropriate energy, and transitions are smooth.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step17_automation.png"
-          },
-          {
-            "number": 18,
-            "title": "Parallel Sidechaining: Blending Ducked and Unducked Signals",
-            "concept": "Blending a sidechained version of a track with the unprocessed original creates controlled ducking without losing energy or presence.",
-            "actions": [
-              "Duplicate your target track or route it to a parallel aux.",
-              "Apply aggressive sidechain compression to the duplicate/aux.",
-              "Blend the heavily ducked signal with the dry original for hybrid control.",
-              "Adjust the balance to achieve the desired ducking intensity."
-            ],
-            "body": "Parallel sidechaining is a technique where you blend a heavily sidechained version of a track with the original, unprocessed version. This creates a hybrid sound where you get the clarity and space benefits of sidechaining without completely losing the track's energy and presence. It's especially useful for maintaining low-end power while still allowing kick clarity.\n\nConcept:\n- The original track stays at full volume, maintaining energy and presence.\n- The sidechained duplicate ducks dramatically when the trigger (e.g., kick) plays.\n- Blending the two creates a sound that's 'mostly there' but with subtle ducking—less obvious than pure sidechain compression, but more effective than no sidechaining.\n\nSetup Method 1: Duplicate Track\n\n1. Duplicate your target track (e.g., bass). Name one 'Bass Dry' and one 'Bass SC.'\n\n2. On the 'Bass SC' track, apply aggressive sidechain compression (8:1 ratio, 10-15dB gain reduction, fast attack, tempo-synced release).\n\n3. Leave the 'Bass Dry' track completely unprocessed (no sidechaining).\n\n4. Balance the two tracks by adjusting their faders:\n   - More 'Bass Dry' = more energy, less ducking.\n   - More 'Bass SC' = more obvious ducking, cleaner kick-bass interaction.\n   - Typical balance: 60% dry, 40% sidechained, but adjust to taste.\n\n5. Group the two tracks for easy level control.\n\nSetup Method 2: Aux Send (True Parallel)\n\n1. Keep your bass track at full volume with no sidechaining.\n\n2. Create an auxiliary track. Name it 'Bass SC Parallel.'\n\n3. Insert an aggressive sidechain compressor on the aux, sidechained to your kick.\n\n4. Send your bass track to this aux via a post-fader send.\n\n5. Blend the aux return level to taste—lower for subtle parallel ducking, higher for more obvious effect.\n\nBenefits:\n- **Maintains Energy:** The dry signal keeps the track feeling powerful and present.\n- **Provides Clarity:** The sidechained signal creates space for the kick without sacrificing too much low-end fullness.\n- **Adjustable Intensity:** You can dial in exactly how much ducking you want by adjusting the blend.\n- **Cleaner Than Moderate Settings:** Often cleaner and more musical than trying to find the 'perfect' moderate sidechain settings on a single track.\n\nApplications:\n- **Kick-Bass:** Parallel sidechaining maintains bass power while allowing kick clarity.\n- **Vocal Clarity:** Blend a heavily ducked music bus with a lightly ducked (or undocked) version for subtle vocal space without obvious pumping.\n- **Creative Pumping:** Use extreme sidechaining on the parallel channel for obvious pumping while the dry signal keeps the track grounded.\n\nAdvanced variations:\n- **Multiband Parallel:** Apply heavy low-end sidechaining on the parallel channel while leaving mids/highs dry.\n- **Frequency-Split Parallel:** Duplicate the track, high-pass the dry version (keeping only upper harmonics), low-pass the sidechained version (keeping only the fundamental), then blend. This lets the bass's 'body' stay present while only the fundamental ducks.\n- **NY Compression + Sidechain:** Combine traditional parallel compression (for density) with parallel sidechaining (for space) for hybrid control.",
-            "symbolName": "arrow.triangle.branch",
-            "visualTitle": "Parallel Sidechaining",
-            "visualCaption": "Blend ducked and dry for hybrid control.",
-            "settings": {
-              "Dry Signal": "100% level, no processing",
-              "Sidechained Signal": "Aggressive settings (8:1, 10-15dB GR)",
-              "Typical Blend": "60% dry, 40% sidechained (adjust to taste)",
-              "Method": "Duplicate track or aux send/return"
-            },
-            "proTip": "Use parallel sidechaining when standard sidechain settings feel either too subtle or too aggressive—the blend gives you precise control in the 'middle ground.'",
-            "avoidThis": "Don't add processing (EQ, reverb, etc.) to only one of the parallel signals unless intentional—this can create phase or tonal imbalance. Keep both clean or process identically.",
-            "checkYourWork": "Your track maintains energy and presence while still creating space for the trigger (e.g., kick clarity without losing bass power).",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step18_parallel_sidechain.png"
-          },
-          {
-            "number": 19,
-            "title": "Using Ghost Triggers for Creative Control",
-            "concept": "Creating a silent 'ghost' trigger track—MIDI or audio—gives you complete control over sidechain rhythm without being tied to existing arrangement elements.",
-            "actions": [
-              "Create a new MIDI or audio track that outputs no sound (muted or routed to nowhere).",
-              "Program the exact rhythm you want for sidechain triggering.",
-              "Use this ghost track as the sidechain input for your compressor/gate.",
-              "Adjust the ghost track's rhythm independently of the actual arrangement."
-            ],
-            "body": "Most sidechaining uses existing arrangement elements—kick drum, hi-hat, vocal—as the trigger. But sometimes you want sidechain ducking or gating to follow a rhythm that doesn't exist in your arrangement. Ghost triggers (also called 'phantom' or 'dummy' triggers) solve this by creating a silent track whose sole purpose is to trigger sidechain processing.\n\nApplications:\n\n**Custom Rhythmic Patterns:** Create complex, syncopated pumping rhythms that aren't tied to your kick drum. For example, trigger sidechain ducking on every eighth note, creating a faster pump than the quarter-note kick provides.\n\n**Gate Sidechaining for Vocal Chopping:** Program a MIDI rhythm that 'slices' a sustained vocal into rhythmic fragments, creating stutter and glitch effects.\n\n**Independent Control:** Change the sidechain rhythm without altering the actual kick drum or drum pattern in your mix.\n\n**Pre-Production Experimentation:** Set up ghost triggers early in production to test different pumping rhythms before committing to a drum pattern.\n\nSetup Method 1: MIDI Ghost Trigger\n\n1. Create a new software instrument track in Logic Pro.\n\n2. Load a simple, percussive instrument (like Ultrabeat or a single drum sample in EXS24) or even leave it empty.\n\n3. Mute the track's output: set the track's output to 'No Output' or reduce its fader to -∞.\n\n4. Program a MIDI pattern with the exact rhythm you want for sidechain triggering. For example, quarter-note triggers, sixteenth-note hi-hat patterns, or syncopated rhythms.\n\n5. In your sidechain compressor (on the target track), set the sidechain input to this ghost MIDI track.\n\n6. The compressor will 'hear' the ghost track's rhythm and duck accordingly, even though the ghost track produces no audible sound in the mix.\n\nSetup Method 2: Audio Ghost Trigger\n\n1. Create a new audio track.\n\n2. Route its output to an unused bus (not the Stereo Output) so it produces no audible sound.\n\n3. Place audio regions (like a kick sample) with the desired rhythm.\n\n4. Use this audio track as the sidechain input for your compressor/gate.\n\nBenefits:\n- **Flexibility:** You can edit the ghost track's rhythm independently without affecting the actual arrangement.\n- **Experimentation:** Try different sidechain rhythms instantly by editing the ghost track's MIDI or audio.\n- **Precision:** Create exact, quantized, or custom rhythms that don't depend on live drum performance timing.\n- **Layered Sidechaining:** Use multiple ghost triggers with different rhythms for different sidechain targets (one ghost for kick-style pumping, another for hi-hat-style gating).\n\nAdvanced techniques:\n- **Ghost Velocity Automation:** Program MIDI velocity changes on the ghost track to create dynamic sidechain intensity—louder ghost notes trigger more compression, quieter notes trigger less.\n- **Ghost Track Effects:** Apply effects (reverb, delay) to the ghost trigger (before muting its output) to create 'smeared' or 'trailing' sidechain triggers for experimental effects.\n- **Multiple Ghost Tracks:** Create separate ghost triggers for different sidechain targets—one for kick-style pumping (quarter notes), one for hi-hat gating (sixteenth notes), one for custom rhythmic effects.",
-            "symbolName": "waveform.badge.magnifyingglass",
-            "visualTitle": "Ghost Trigger Control",
-            "visualCaption": "Silent trigger tracks for custom rhythms.",
-            "settings": {
-              "MIDI Ghost": "Software instrument track, output muted or to 'No Output'",
-              "Audio Ghost": "Audio track routed to unused bus (not Stereo Out)",
-              "Rhythm": "Program exact pattern for sidechain triggering",
-              "Use Cases": "Custom pumping, vocal chopping, experimental gating"
-            },
-            "proTip": "Use a simple, short sample (like a single kick or click) on your ghost trigger track for clean, consistent triggering. Avoid complex, sustained sounds which may cause erratic compressor response.",
-            "avoidThis": "Don't forget to mute or re-route the ghost track's output—if it's audible in your mix, it will create unwanted clicks or drum sounds.",
-            "checkYourWork": "Your sidechain processing follows the exact custom rhythm you programmed, independent of the actual arrangement. The ghost track produces no audible sound.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step19_ghost_trigger.png"
-          },
-          {
-            "number": 20,
-            "title": "Final Checklist and Best Practices",
-            "concept": "A final review of sidechaining best practices ensures your implementation is clean, musical, and appropriate for your production goals.",
-            "actions": [
-              "Review all sidechain instances to verify appropriate intensity and settings.",
-              "Check for artifacts: clicks, pumping, distortion, or unnatural movement.",
-              "Test your mix in mono, at low volume, and on multiple playback systems.",
-              "Verify sidechain processing serves the music, not just the technique."
-            ],
-            "body": "Before finalizing your mix, run through this comprehensive sidechaining checklist to ensure professional results:\n\n**1. Verify Signal Routing:**\n- Confirm every sidechain compressor/gate is receiving the correct trigger source.\n- Check that target tracks are being affected (watch the gain-reduction meter).\n- Ensure no accidental routing to Stereo Out or unintended buses.\n\n**2. Check for Artifacts:**\n- Listen for clicks or pops (indicates attack/release too fast).\n- Listen for harsh, unmusical pumping (reduce ratio or raise threshold).\n- Listen for distortion or harshness (reduce gain reduction or change compressor type).\n- Listen for phase issues or hollow sound (check correlation meter, especially in mono).\n\n**3. Test Across Playback Systems:**\n- Check in mono: does the sidechaining translate well or cause problems?\n- Check at low volume: is the ducking still audible and appropriate?\n- Check on earbuds/phone speakers: does the low-end management still work?\n- Check on studio monitors: is the effect too obvious or too subtle?\n\n**4. Verify Musical Appropriateness:**\n- Does the sidechaining support the genre? (Transparent for pop, obvious for EDM, functional for podcasts)\n- Does it support the song's energy arc? (Subtle in verses, heavier in choruses, or consistent throughout?)\n- Does it solve a real problem (masking, clutter, lack of space) or is it arbitrary?\n\n**5. Review Intensity Across All Instances:**\n- If using multiple sidechain compressors, do they all use appropriate settings for their role?\n- Are some elements over-sidechained (losing energy) while others are under-sidechained (still masking)?\n- Is the overall mix stable, or does excessive sidechaining make everything feel pumping and unstable?\n\n**6. Bypass Test:**\n- Bypass all sidechain compressors at once and compare to the sidechained version.\n- The sidechained version should sound clearly better (clearer, more spacious, better separation).\n- If bypassing sounds better, you've over-sidechained—reduce intensity or remove unnecessary instances.\n\n**7. CPU and Session Management:**\n- Verify CPU load is reasonable (bus-based sidechaining helps if CPU is high).\n- Name all sidechain compressors clearly ('SC to Kick,' 'SC to Vocal') for easy troubleshooting.\n- Document your sidechain routing in session notes if the session is complex.\n\n**8. Genre-Specific Final Checks:**\n- **Pop/Rock:** Vocals clear? Low end tight? No obvious pumping in melodic elements?\n- **EDM:** Pumping obvious and musical? Tempo-synced and groovy? Energy maintained?\n- **Hip-Hop:** Kick-bass separation clean? Upper mix stable?\n- **Podcast:** Dialogue 100% intelligible? Background ducks appropriately?\n\n**9. Automation Review:**\n- If using sidechain automation, verify smooth transitions between sections.\n- Ensure automation curves are gradual, not stepped (which causes audible jumps).\n\n**10. Final Reference Check:**\n- A/B your mix against professional references in your genre.\n- Does your sidechaining match the intensity and character of those references?\n\nBest Practices Summary:\n- **Start subtle, add intensity only if needed.** It's easier to add more sidechaining than to undo over-sidechaining.\n- **Use bus-based sidechaining** for CPU efficiency and cohesion in complex sessions.\n- **Match genre expectations.** Don't apply EDM pumping to jazz, or subtle pop sidechaining to house music.\n- **Use dynamic EQ or multiband sidechaining** for transparent, surgical space creation.\n- **Test in mono and at low volume** to verify translation.\n- **Sidechain EQ filtering** improves triggering consistency and reduces artifacts.\n- **Automate sidechain intensity** to match song sections and energy arc.\n- **Reference professional tracks** before finalizing your sidechaining decisions.\n\nSidechaining is one of the most powerful tools in modern mixing and production. When done well, it creates space, clarity, and movement that elevates your mix. When done poorly, it creates pumping, instability, and listener fatigue. Following this checklist ensures you land on the professional side of that divide.",
-            "symbolName": "checkmark.seal.fill",
-            "visualTitle": "Sidechaining Best Practices",
-            "visualCaption": "Final checklist for clean, professional results.",
-            "settings": {
-              "Routing": "Verify all sidechain sources and targets",
-              "Artifacts": "No clicks, harshness, or unnatural pumping",
-              "Translation": "Test mono, low volume, multiple systems",
-              "Musical Fit": "Supports genre, song structure, and energy",
-              "Bypass Test": "Sidechained version clearly better"
-            },
-            "proTip": "Create a 'Sidechain Template' session with pre-configured buses, compressors, and routing for your typical workflow. This speeds up future projects and ensures consistent, professional results.",
-            "avoidThis": "Don't assume your sidechaining is correct without testing—bypass and compare, check in mono, and verify on multiple systems before calling a mix finished.",
-            "checkYourWork": "Your sidechaining is clean, musical, genre-appropriate, and translates well across playback systems. It solves real problems without introducing new ones.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step16_genre_comparison.png"
-          }
-        ]
-      },
-      {
-        "id": "parallel-busses",
-        "title": "Parallel Busses: Advanced Mixing Technique",
-        "series": "Advanced Mixing Series",
-        "summary": "Learn practical parallel routing in Logic Pro for compression, saturation, and time-based effects while preserving transient clarity and musical dynamics.",
-        "duration": "28 min read",
-        "symbolName": "arrow.triangle.branch",
-        "badges": [
-          "Advanced",
-          "Creative",
-          "Technique"
-        ],
-        "isFeatured": true,
-        "checklist": [
-          "Create dedicated parallel aux buses and name them clearly.",
-          "Use pre-fader sends when you need independent blend control.",
-          "Set up parallel compression to add density without flattening transients.",
-          "Use EQ on returns to keep low-end and harshness controlled.",
-          "Level-match and A/B returns against the dry signal.",
-          "Check phase and mono compatibility before finalizing."
-        ],
-        "steps": [
-          {
-            "number": 1,
-            "title": "Understand the Parallel Workflow",
-            "concept": "Parallel processing blends a heavily processed duplicate with the original to gain impact without sacrificing natural tone.",
-            "actions": [
-              "Keep your dry source intact.",
-              "Route a send to a dedicated aux return.",
-              "Blend processed return until it supports the source."
-            ],
-            "body": "This approach lets you use aggressive settings (compression, distortion, filtering) while preserving clarity from the dry path.",
-            "symbolName": "arrow.triangle.branch",
-            "visualTitle": "Dry + Processed Blend",
-            "visualCaption": "Power and control without destroying source detail.",
-            "settings": {
-              "Starting Blend": "10-30% return level",
-              "Signal Flow": "Dry track + aux return"
-            },
-            "proTip": "Set up reusable parallel aux templates for speed across sessions.",
-            "avoidThis": "Do not over-blend returns until the dry source disappears.",
-            "checkYourWork": "Bypassing the return reduces impact, but the mix still sounds natural.",
-            "stepScreenshot": "/assets/training/parallel-busses/step1_concept_diagram.png"
-          },
-          {
-            "number": 2,
-            "title": "Route Parallel Compression",
-            "concept": "Parallel compression adds body and sustain while leaving transient attack intact.",
-            "actions": [
-              "Send drum or vocal bus to an aux with a compressor.",
-              "Use higher ratio and deeper gain reduction than you would in serial mode.",
-              "Blend the return under the dry signal."
-            ],
-            "body": "On drums, this increases perceived power. On vocals, it can improve consistency and intelligibility in dense sections.",
-            "symbolName": "arrow.down.circle.fill",
-            "visualTitle": "Crush Then Blend",
-            "visualCaption": "Aggressive return, subtle mix contribution.",
-            "settings": {
-              "Typical Ratio": "6:1 to 12:1",
-              "Gain Reduction": "8-15 dB on return path"
-            },
-            "proTip": "Shape return tone with EQ after compression to avoid mud.",
-            "avoidThis": "Avoid stacking multiple parallel compressors without purpose.",
-            "checkYourWork": "The return adds energy and sustain without pumping artifacts.",
-            "stepScreenshot": "/assets/training/parallel-busses/step3_drum_compression.png"
-          },
-          {
-            "number": 3,
-            "title": "Use Parallel Reverb and Saturation",
-            "concept": "Parallel time and harmonic effects create size and color while maintaining source focus.",
-            "actions": [
-              "Use separate aux returns for short room, plate, and saturation.",
-              "Filter reverb returns to control low-end wash.",
-              "Automate return levels for transitions and choruses."
-            ],
-            "body": "Parallel reverbs improve depth without clouding the center. Parallel saturation improves perceived loudness and texture.",
-            "symbolName": "sparkles",
-            "visualTitle": "Depth and Harmonics",
-            "visualCaption": "Space and color under the dry signal.",
-            "settings": {
-              "HPF on Reverb Return": "150-300 Hz",
-              "Return Strategy": "Separate aux by effect type"
-            },
-            "proTip": "Short reverbs often read cleaner than long tails in busy arrangements.",
-            "avoidThis": "Do not feed every track into every return bus.",
-            "checkYourWork": "Mix feels wider and richer while lead elements stay clear.",
-            "stepScreenshot": "/assets/training/parallel-busses/step4_reverb_routing.png"
-          },
-          {
-            "number": 4,
-            "title": "Validate Phase and Translation",
-            "concept": "Parallel chains can introduce phase and masking if unchecked.",
-            "actions": [
-              "A/B dry-only vs blend at matched loudness.",
-              "Check mono fold-down for cancellations.",
-              "Trim return timing/phase if low-end weakens."
-            ],
-            "body": "Final checks ensure parallel benefits survive across speakers, headphones, and mono playback.",
-            "symbolName": "checkmark.seal.fill",
-            "visualTitle": "Final Safety Pass",
-            "visualCaption": "Phase-safe, mono-safe, mix-safe.",
-            "settings": {
-              "A/B Method": "Matched loudness comparison",
-              "Mono Check": "No major center collapse"
-            },
-            "proTip": "Keep one reference snapshot with all returns bypassed.",
-            "avoidThis": "Avoid judging return tone in solo for final decisions.",
-            "checkYourWork": "Parallel processing improves excitement and still translates cleanly.",
-            "stepScreenshot": "/assets/training/parallel-busses/step10_complete_workflow.png"
-          }
-        ]
-      },
-      {
-        "id": "stereo-tricks",
-        "title": "Stereo Tricks",
-        "series": "Advanced Mixing Techniques",
-        "summary": "Build width and depth with panning, mid-side decisions, Haas concepts, and stereo automation while keeping mono compatibility intact.",
-        "duration": "35 min read",
-        "symbolName": "speaker.wave.3.fill",
-        "badges": [
-          "Advanced",
-          "Professional",
-          "Mixing"
-        ],
-        "isFeatured": true,
-        "checklist": [
-          "Keep foundational elements anchored in the center.",
-          "Use panning symmetry to balance competing parts.",
-          "Apply width tools in controlled ranges.",
-          "Use stereo effects to support arrangement roles.",
-          "Automate width by section for energy changes.",
-          "Verify correlation and mono playback before bounce."
-        ],
-        "steps": [
-          {
-            "number": 1,
-            "title": "Map the Stereo Field",
-            "concept": "Intentional placement reduces masking and improves focus.",
-            "actions": [
-              "Center kick, bass, snare, and lead vocal.",
-              "Place support elements in balanced left/right positions.",
-              "Use fewer hard-pan choices than you think."
-            ],
-            "body": "A disciplined layout keeps the center stable while creating width from supporting instruments.",
-            "symbolName": "scope",
-            "visualTitle": "Stereo Layout",
-            "visualCaption": "Anchor core, spread support.",
-            "settings": {
-              "Core Elements": "Center",
-              "Support Range": "Moderate L/R offsets first"
-            },
-            "proTip": "Decide panning in context, not in solo.",
-            "avoidThis": "Do not leave both sides crowded with similar timbres.",
-            "checkYourWork": "Center remains strong while sides provide clear separation.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step1_stereo_field_basics.png"
-          },
-          {
-            "number": 2,
-            "title": "Use Width Tools Carefully",
-            "concept": "Stereo widening can help size, but overuse causes phase issues and weak mono translation.",
-            "actions": [
-              "Apply Direction Mixer or equivalent to non-foundational layers.",
-              "Increase width in small increments.",
-              "Monitor correlation while widening."
-            ],
-            "body": "Widening works best on pads, FX, doubles, and ambience, not bass-heavy or lead-anchor tracks.",
-            "symbolName": "arrow.left.and.right.righttriangle.left.righttriangle.right",
-            "visualTitle": "Controlled Widening",
-            "visualCaption": "Small moves, safer translation.",
-            "settings": {
-              "Typical Spread Range": "100-130%",
-              "Correlation Goal": "Stay safely above negative values"
-            },
-            "proTip": "If mono loses punch, pull width back before adding more EQ.",
-            "avoidThis": "Avoid widening everything in the same frequency range.",
-            "checkYourWork": "Stereo image feels larger, and mono still sounds solid.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step4_direction_mixer.png"
-          },
-          {
-            "number": 3,
-            "title": "Create Depth With Stereo FX",
-            "concept": "Short delays, subtle modulation, and filtered reverbs add depth without blurring articulation.",
-            "actions": [
-              "Use short stereo delays for spatial separation.",
-              "Filter returns to avoid low-end smear.",
-              "Balance wet effects by section density."
-            ],
-            "body": "Time-based stereo effects should support arrangement roles rather than compete with the center.",
-            "symbolName": "timelapse",
-            "visualTitle": "Depth Through Time",
-            "visualCaption": "Stereo space with articulation preserved.",
-            "settings": {
-              "Delay Use": "Short and level-controlled",
-              "Return EQ": "HPF/LPF to fit the mix"
-            },
-            "proTip": "Keep vocal clarity by ducking FX returns around key phrases.",
-            "avoidThis": "Do not use long, bright tails on every prominent element.",
-            "checkYourWork": "Mix sounds deeper and wider without turning hazy.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step10_stereo_delay.png"
-          },
-          {
-            "number": 4,
-            "title": "Automate Width by Section",
-            "concept": "Width contrast between verse and chorus increases perceived impact.",
-            "actions": [
-              "Start verses narrower for intimacy.",
-              "Open choruses wider for lift and release.",
-              "Use smooth automation ramps at transitions."
-            ],
-            "body": "Dynamic width feels more musical than static maximum spread across the entire song.",
-            "symbolName": "waveform.path.badge.plus",
-            "visualTitle": "Section Contrast",
-            "visualCaption": "Narrow-to-wide movement adds energy.",
-            "settings": {
-              "Verse Spread": "80-100%",
-              "Chorus Spread": "120-140%"
-            },
-            "proTip": "Automate supporting buses, not every individual track first.",
-            "avoidThis": "Avoid abrupt width jumps that distract the listener.",
-            "checkYourWork": "Section changes feel larger while center remains stable.",
             "stepScreenshot": "/assets/training/stereo-tricks/step22_stereo_automation.png"
           }
         ]

--- a/public/content/en/content.json
+++ b/public/content/en/content.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "contentVersion": "20260510T145536Z",
-  "generatedAt": "2026-05-10T14:55:36.758Z",
+  "contentVersion": "20260510T152015Z",
+  "generatedAt": "2026-05-10T15:20:15.884Z",
   "minAppVersion": "1.0.0",
   "navItems": [
     {
@@ -11159,7 +11159,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq1_save_format_overview.png"
           },
           {
-            "number": 1,
+            "number": 2,
             "title": "Save Format Visual Examples",
             "concept": "Visual reference showing how Logic packages appear in Finder and what's contained inside.",
             "actions": [
@@ -11178,7 +11178,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq1_package_contents.png"
           },
           {
-            "number": 2,
+            "number": 3,
             "title": "I have limited hard drive space on my computer, is it okay to save files to a USB drive or network storage? What about plugins or samples?",
             "concept": "Storage location affects performance, reliability, and workflow speed. Understanding the hierarchy of storage types prevents corruption and frustration.",
             "actions": [
@@ -11202,7 +11202,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq2_storage_types.png"
           },
           {
-            "number": 2,
+            "number": 4,
             "title": "Storage Best Practices",
             "concept": "Practical workflows for managing projects across multiple storage locations.",
             "actions": [
@@ -11225,7 +11225,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq2_folder_organization.png"
           },
           {
-            "number": 3,
+            "number": 5,
             "title": "Should I change the buffer when mixing or recording?",
             "concept": "Buffer size balances input monitoring latency against CPU overhead. Recording needs low latency; mixing benefits from high efficiency.",
             "actions": [
@@ -11248,7 +11248,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq3_buffer_settings.png"
           },
           {
-            "number": 3,
+            "number": 6,
             "title": "Buffer Size in Practice",
             "concept": "Visual examples of buffer settings for different workflow scenarios.",
             "actions": [
@@ -11270,7 +11270,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq3_latency_comparison.png"
           },
           {
-            "number": 4,
+            "number": 7,
             "title": "Do I really need to buy plugins or can I use the stock plugins?",
             "concept": "Logic's included plugins are professional-grade tools. Third-party plugins offer different workflows, character, or specialized functions, but aren't required for quality results.",
             "actions": [
@@ -11292,7 +11292,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq4_stock_plugins_overview.png"
           },
           {
-            "number": 4,
+            "number": 8,
             "title": "Essential Stock Plugin Examples",
             "concept": "Visual tour of Logic's most powerful included plugins and their professional applications.",
             "actions": [
@@ -11315,7 +11315,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq4_vintage_compressors.png"
           },
           {
-            "number": 5,
+            "number": 9,
             "title": "I finished a song, how do I export it?",
             "concept": "Exporting (bouncing) renders your mix to a stereo file. Proper bounce settings preserve quality and ensure compatibility with mastering or distribution.",
             "actions": [
@@ -11338,7 +11338,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq5_bounce_dialog.png"
           },
           {
-            "number": 5,
+            "number": 10,
             "title": "Bounce Settings Explained",
             "concept": "Understanding each bounce option helps you choose the right settings for different delivery contexts.",
             "actions": [
@@ -11361,7 +11361,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq5_bounce_formats.png"
           },
           {
-            "number": 6,
+            "number": 11,
             "title": "I recorded a track but I barely see the waveform or the waveform is really large, what should I visually be looking for to know the levels are good?",
             "concept": "Waveform size indicates recording level. Healthy recordings show clear, visible waveforms without clipping. Understanding visual cues prevents problems in mixing.",
             "actions": [
@@ -11384,7 +11384,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq6_waveform_good_level.png"
           },
           {
-            "number": 6,
+            "number": 12,
             "title": "Waveform Problems and Solutions",
             "concept": "Visual examples of too-quiet, too-loud, and properly recorded waveforms with remediation strategies.",
             "actions": [
@@ -11406,7 +11406,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq6_waveform_comparison.png"
           },
           {
-            "number": 7,
+            "number": 13,
             "title": "Can I record several takes and choose parts of each?",
             "concept": "Logic's comp recording feature (take folders and comping) allows you to record multiple passes and assemble the best composite performance from them.",
             "actions": [
@@ -11428,7 +11428,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq7_take_folder_overview.png"
           },
           {
-            "number": 7,
+            "number": 14,
             "title": "Comping in Detail",
             "concept": "Visual walkthrough of comping techniques, crossfade adjustments, and advanced comp editing.",
             "actions": [
@@ -11450,7 +11450,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq7_comping_workflow.png"
           },
           {
-            "number": 8,
+            "number": 15,
             "title": "If I bounce a track do I lose the original?",
             "concept": "Bouncing in place renders a track to audio but doesn't delete the original. Understanding destructive vs non-destructive processes protects your work.",
             "actions": [
@@ -11473,7 +11473,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq8_bounce_in_place.png"
           },
           {
-            "number": 8,
+            "number": 16,
             "title": "Bounce in Place Options",
             "concept": "Detailed look at Bounce in Place settings and when to use each option.",
             "actions": [
@@ -11496,7 +11496,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq8_bounce_settings.png"
           },
           {
-            "number": 9,
+            "number": 17,
             "title": "Should I be mixing in mono or stereo?",
             "concept": "Mixing in mono helps ensure balance and frequency clarity before stereo imaging is applied. Both mono and stereo monitoring are essential at different stages.",
             "actions": [
@@ -11518,7 +11518,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq9_mono_stereo_comparison.png"
           },
           {
-            "number": 9,
+            "number": 18,
             "title": "Mono Compatibility in Practice",
             "concept": "Understanding phase correlation, stereo widening tools, and mono-safe mixing techniques.",
             "actions": [
@@ -11541,7 +11541,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq9_correlation_meter.png"
           },
           {
-            "number": 10,
+            "number": 19,
             "title": "How do I make the waveform bigger so I can see it?",
             "concept": "Logic offers multiple zoom controls for waveforms and track heights. Understanding these tools improves editing speed and visual clarity.",
             "actions": [
@@ -11564,7 +11564,7 @@
             "stepScreenshot": "/assets/training/frequently-asked-questions/faq10_track_zoom.png"
           },
           {
-            "number": 10,
+            "number": 20,
             "title": "Zoom Workflows for Editing",
             "concept": "Practical zoom workflows for common editing tasks: comping, cleaning up, arranging, and mixing.",
             "actions": [
@@ -11882,7 +11882,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step1_concept_diagram.png"
           },
           {
-            "number": 2,
+            "number": 12,
             "title": "Routing Methods in Logic Pro",
             "concept": "Logic offers multiple ways to create parallel paths: aux sends, track stacks, and manual routing via busses. Each method has strengths for different workflows.",
             "actions": [
@@ -11907,7 +11907,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step2_routing_sends.png"
           },
           {
-            "number": 3,
+            "number": 13,
             "title": "Parallel Compression on Drums",
             "concept": "Parallel compression (often called 'New York compression') adds density, sustain, and power to drums without squashing transients. It's the most popular parallel processing technique.",
             "actions": [
@@ -11933,7 +11933,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step3_drum_compression.png"
           },
           {
-            "number": 4,
+            "number": 14,
             "title": "Parallel Reverb for Depth Control",
             "concept": "Parallel reverb routing gives you precise control over wet/dry balance, allows independent processing of the reverb return, and prevents the reverb from smearing your dry signal.",
             "actions": [
@@ -11959,7 +11959,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step4_reverb_routing.png"
           },
           {
-            "number": 5,
+            "number": 15,
             "title": "Parallel Saturation and Harmonic Enhancement",
             "concept": "Parallel saturation adds warmth, grit, and harmonic richness without turning your mix into distorted mush. It's especially powerful on vocals, bass, and mix buses.",
             "actions": [
@@ -11985,7 +11985,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step5_saturation_chain.png"
           },
           {
-            "number": 6,
+            "number": 16,
             "title": "Balancing and Blending Parallel Chains",
             "concept": "The mix between your dry and parallel signals determines whether the technique enhances or destroys your sound. Developing an ear for the optimal blend is a core skill.",
             "actions": [
@@ -12010,7 +12010,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step6_blending_comparison.png"
           },
           {
-            "number": 7,
+            "number": 17,
             "title": "Advanced Applications: Multi-Band and Frequency-Specific Parallel Processing",
             "concept": "Parallel processing doesn't have to affect the entire frequency spectrum. Targeting specific frequency bands unlocks surgical control and creative possibilities.",
             "actions": [
@@ -12034,7 +12034,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step7_multiband_parallel.png"
           },
           {
-            "number": 8,
+            "number": 18,
             "title": "Common Mistakes and How to Avoid Them",
             "concept": "Parallel processing is powerful but easy to misuse. Understanding common pitfalls saves you time and improves your results.",
             "actions": [
@@ -12055,7 +12055,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step8_common_mistakes.png"
           },
           {
-            "number": 9,
+            "number": 19,
             "title": "Genre-Specific Parallel Processing Applications",
             "concept": "Different musical styles benefit from different parallel processing approaches. Tailoring your technique to your genre improves translation and impact.",
             "actions": [
@@ -12082,7 +12082,7 @@
             "stepScreenshot": "/assets/training/parallel-busses/step9_genre_applications.png"
           },
           {
-            "number": 10,
+            "number": 20,
             "title": "Putting It All Together: A Complete Parallel Processing Workflow",
             "concept": "Integrating parallel processing into your standard mixing workflow creates consistent, professional results without adding confusion or clutter.",
             "actions": [
@@ -12108,7 +12108,1142 @@
             "stepScreenshot": "/assets/training/parallel-busses/step6_blending_comparison.png"
           },
           {
-            "number": 12,
+            "number": 21,
+            "title": "Understanding the Stereo Field",
+            "concept": "The stereo field is the perceived horizontal space between left and right speakers where you position sounds in your mix.",
+            "actions": [
+              "Visualize the stereo field as a 180-degree arc from hard left (-64) through center (0) to hard right (+63).",
+              "Identify placement zones: center for foundational elements, 30-45° for rhythm parts, 60-90° for supporting elements.",
+              "Learn which instruments benefit most from stereo placement versus staying centered."
+            ],
+            "body": "Understanding the stereo field is fundamental to creating professional-sounding mixes with proper width, depth, and separation. The stereo field represents the horizontal space between your left and right speakers, and how you position sounds within this space dramatically affects your mix's clarity, power, and dimension.\n\nThink of the stereo field as a stage. Just as musicians occupy different positions on a physical stage, tracks in your mix occupy different positions in the stereo field. The center position is the most powerful and focused location—it's where the listener's attention naturally goes first. Foundational elements like kick drum, snare, bass guitar, and lead vocals almost always occupy the center because these are the elements that drive the song forward and need maximum impact and mono compatibility.\n\nThe mid-field positions (roughly 30-45 degrees left or right) are ideal for rhythm elements that support the foundation but don't need to be centered. Rhythm guitars, keyboard parts, and background vocals often sit in these zones, creating width while maintaining a cohesive relationship with the centered elements.\n\nThe wide positions (60-90 degrees) are reserved for atmospheric elements, pads, effects, stereo-widened instruments, and decorative parts that fill out the mix without competing for attention with core elements. These positions create the sense of space and immersion that makes mixes feel large and engaging.\n\nEffective stereo placement isn't just about spreading things out randomly—it's about creating balance, clarity, and intentional focus. A well-planned stereo field guides the listener's ear through the arrangement, prevents frequency masking by separating competing elements spatially, and creates a sense of space and professionalism that distinguishes amateur mixes from pro-level work.",
+            "symbolName": "speaker.wave.3.fill",
+            "visualTitle": "Stereo Field Basics",
+            "visualCaption": "Placement zones from center to wide positions.",
+            "settings": {
+              "Center Zone (0°)": "Kick, snare, bass, lead vocal",
+              "Inner Zone (30-45°)": "Rhythm guitars, keys, supporting vocals",
+              "Outer Zone (60-90°)": "Pads, effects, atmosphere, wide elements"
+            },
+            "proTip": "Visualize your stereo field on paper before mixing—sketch out where each element should sit to create intentional balance and avoid cluttered zones.",
+            "avoidThis": "Don't pan everything to extremes thinking more width is always better. An empty center leaves your mix weak and unfocused.",
+            "checkYourWork": "Your mix has clear focal points in the center, supporting elements create width without feeling disconnected, and the stereo field feels balanced and intentional.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step1_stereo_field_basics.png"
+          },
+          {
+            "number": 22,
+            "title": "Mastering Pan Controls",
+            "concept": "Logic Pro offers multiple panning modes that affect how stereo signals behave when panned off-center.",
+            "actions": [
+              "Right-click any pan knob to access pan mode options: Stereo Pan, Balance, and Binaural Pan.",
+              "Use Stereo Pan mode to preserve stereo width when panning stereo sources off-center.",
+              "Use Balance mode for simple left-right balance control of stereo signals.",
+              "Adjust the stereo spread using the white squares on the pan line in Stereo Pan mode."
+            ],
+            "body": "Logic Pro's pan controls are more sophisticated than simple left-right positioning. Understanding the different pan modes and how to use them effectively is crucial for professional stereo control.\n\nThe standard pan mode works perfectly for mono sources—turning the knob positions the sound anywhere from hard left to hard right. But what happens when you pan a stereo signal? This is where Logic's multiple pan modes become essential.\n\nStereo Pan mode (accessed by right-clicking the pan knob) preserves the stereo width of a signal when you pan it off-center. If you have a stereo synth pad panned to center, it maintains its full stereo width. When you pan it 30 degrees left using Stereo Pan mode, the entire stereo image moves left while keeping its width intact. This is ideal for moving stereo sources around the field without collapsing them to mono.\n\nIn Stereo Pan mode, you'll also notice two small white squares on the pan line. These control the stereo spread or width of the signal. Dragging them closer together narrows the stereo image, while pulling them apart widens it. This gives you precise control over both position and width from a single control.\n\nBalance mode, on the other hand, simply adjusts the relative level between left and right channels without preserving spatial characteristics. It's useful for quick fixes like correcting a slightly off-center stereo recording, but it doesn't maintain stereo imaging the way Stereo Pan does.\n\nBinaural Pan mode uses head-related transfer functions (HRTF) for 3D spatial positioning, primarily useful when mixing for headphones or creating immersive binaural content.\n\nKnowing which mode to use for each situation—Stereo Pan for moving and shaping stereo sources, standard pan for mono sources, and Balance for quick level corrections—gives you precise control over your stereo field.",
+            "symbolName": "dial.max",
+            "visualTitle": "Pan Control Modes",
+            "visualCaption": "Stereo Pan preserves width when panning.",
+            "settings": {
+              "Stereo Pan": "Preserves width, move stereo sources",
+              "Balance": "Simple L/R level control",
+              "Binaural Pan": "3D spatial positioning for headphones"
+            },
+            "proTip": "Set Stereo Pan as your default pan mode for stereo channels by right-clicking and selecting it once—Logic remembers your preference per channel type.",
+            "avoidThis": "Don't use Balance mode when you actually want to move a stereo image—it won't maintain the spatial characteristics properly.",
+            "checkYourWork": "Stereo sources maintain their width and character when panned, and you can precisely control both position and spread from the pan control.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step2_pan_controls.png"
+          },
+          {
+            "number": 23,
+            "title": "Understanding Pan Law",
+            "concept": "Pan law determines how much signal level decreases at the center position to maintain constant perceived loudness across the stereo field.",
+            "actions": [
+              "Check your pan law setting in Logic Pro > Settings > Audio > General.",
+              "Understand the three common pan law standards: -3dB, -4.5dB, and -6dB.",
+              "Choose -3dB for most modern music production to maintain consistent levels."
+            ],
+            "body": "Pan law is one of those invisible but critical aspects of mixing that affects how your levels translate across the stereo field. It determines how signal level changes as you pan sounds from left or right toward the center position.\n\nHere's the core problem pan law solves: when you pan a mono sound to hard left, all its energy goes to the left speaker. When you pan it to hard right, all energy goes to the right speaker. But when you pan it to center, that same sound comes equally from both speakers, which means your ears receive it from two sources instead of one. Without compensation, this makes centered sounds perceptually louder than panned sounds.\n\nPan law applies attenuation (volume reduction) at the center position to maintain consistent perceived loudness as sounds move across the stereo field. The number indicates how much attenuation is applied: -3dB pan law means center-panned signals are reduced by 3 decibels, -4.5dB means 4.5 decibels, and -6dB means 6 decibels.\n\nThe -3dB pan law is the modern standard and most common choice. It maintains fairly constant perceived loudness as you pan, which is what most contemporary producers expect. This setting works well for digital mixing and most musical styles.\n\nThe -4.5dB pan law is sometimes called the 'compromise' setting—it sits between -3dB and -6dB and was common in older analog consoles. Some engineers prefer it for its slightly different spatial character.\n\nThe -6dB pan law applies the most center attenuation. This creates a stronger sense of separation between panned elements, as centered sounds are quieter relative to hard-panned sounds. It's less common in modern production but can be useful for specific artistic choices.\n\nThe most important thing about pan law: be consistent within a project. Changing pan law mid-mix will alter your relative levels and balance. Choose a pan law setting that matches your workflow and stick with it across all your projects for consistent results and muscle memory.",
+            "symbolName": "ruler",
+            "visualTitle": "Pan Law Comparison",
+            "visualCaption": "Center attenuation maintains consistent loudness.",
+            "settings": {
+              "-3dB Pan Law": "Modern standard, constant perceived loudness",
+              "-4.5dB Pan Law": "Compromise, vintage console style",
+              "-6dB Pan Law": "Maximum center attenuation, strong separation"
+            },
+            "proTip": "If you're collaborating or sending projects to other engineers, note your pan law setting in project documentation so everyone works with the same standard.",
+            "avoidThis": "Don't change pan law settings mid-project—it will throw off your carefully balanced levels and relative positions.",
+            "checkYourWork": "Your levels remain perceptually consistent as you pan elements across the field, and your pan law matches industry standards you're working within.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step3_pan_law_comparison.png"
+          },
+          {
+            "number": 24,
+            "title": "Introduction to Direction Mixer",
+            "concept": "Logic Pro's Direction Mixer is a powerful stereo imaging plugin that provides precise control over stereo direction, spread, and width beyond standard pan controls.",
+            "actions": [
+              "Insert Direction Mixer on any stereo channel or bus.",
+              "Use the Direction knob to set the center position of the stereo image (0-180 degrees).",
+              "Adjust the Spread slider to control stereo width from mono (0%) to beyond normal width (200%).",
+              "Experiment with LR, Split, and M/S modes for different stereo processing approaches."
+            ],
+            "body": "The Direction Mixer is one of Logic Pro's most versatile stereo imaging tools, offering far more control than standard pan knobs. It's essentially a sophisticated stereo field manipulator that can position, widen, narrow, and even rotate stereo images with surgical precision.\n\nThe Direction knob controls the center position of your stereo image, ranging from 0 to 180 degrees. At 0 degrees, the image is centered normally. As you increase the value, the entire stereo image rotates. At 90 degrees, the image is rotated 90 degrees to the left. At 180 degrees, the left and right channels are completely swapped. This is incredibly useful for correcting stereo recordings that were tracked with reversed channels, or for creative stereo positioning that goes beyond simple panning.\n\nThe Spread slider controls the width of the stereo image. At 100%, the signal passes through at normal stereo width. At 0%, the signal is collapsed to mono. Values above 100% widen the stereo image beyond its original width, up to 200%. This widening can make sources feel more spacious and immersive, though extreme values may cause phase issues that affect mono compatibility.\n\nThe Direction Mixer operates in three modes: LR mode (standard left-right stereo processing), Split mode (frequency-dependent stereo control), and M/S mode (mid-side processing). Each mode offers different capabilities for shaping your stereo image.\n\nOne of the Direction Mixer's greatest strengths is its ability to process stereo width without introducing the harsh artifacts that simpler stereo widening plugins create. It uses sophisticated algorithms that maintain phase relationships while adjusting width, making it much safer for professional applications.\n\nCommon uses for Direction Mixer include: widening stereo keyboards and pads for larger-than-life presence, narrowing stereo samples that are too wide to sit well in a mix, correcting reversed-channel recordings, and creating frequency-dependent width processing where low frequencies stay narrow while high frequencies spread wide.",
+            "symbolName": "arrow.left.and.right.circle",
+            "visualTitle": "Direction Mixer Plugin",
+            "visualCaption": "Precise control over direction, spread, and width.",
+            "settings": {
+              "Direction": "0° = centered, 90° = rotated left, 180° = channels swapped",
+              "Spread": "0% = mono, 100% = normal, 200% = maximum width",
+              "Modes": "LR, Split (frequency-dependent), M/S (mid-side)"
+            },
+            "proTip": "Use Direction Mixer's Spread control between 0-100% to narrow overly-wide stereo samples so they fit better in dense mixes, rather than just lowering their volume.",
+            "avoidThis": "Don't push Spread above 150% on bass-heavy material—extreme widening at low frequencies causes phase cancellation and weak mono translation.",
+            "checkYourWork": "Your stereo sources have the exact width and position you intend, and they maintain clarity and power both in stereo and when checked in mono.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step5_spread_comparison.png"
+          },
+          {
+            "number": 25,
+            "title": "Controlling Stereo Spread",
+            "concept": "Stereo spread adjustments allow you to make elements narrower or wider to fit your mix, creating space, separation, and dimension.",
+            "actions": [
+              "Narrow overly-wide samples to create space in your mix (Spread 40-80%).",
+              "Widen pads and atmospheres for immersive depth (Spread 120-150%).",
+              "Keep low-frequency elements narrow (Spread 0-50%) to maintain mono compatibility.",
+              "Check phase correlation when widening to ensure mono translation."
+            ],
+            "body": "Controlling stereo spread is like adjusting the physical size of each element in your mix. Just as a drummer takes up more physical space on stage than a singer at a microphone, some elements in your mix should occupy more of the stereo field than others.\n\nNarrowing stereo spread is often just as important as widening. Many loops, samples, and virtual instruments come pre-processed with heavy stereo width that sounds impressive in solo but doesn't fit in a dense mix. These overly-wide elements push everything else out of the way and create a cluttered, unfocused stereo field. By narrowing their spread to 40-80%, you make room for other elements while still maintaining some stereo character.\n\nPads, string sections, ambient textures, and background vocals benefit from moderate to wide spread (120-150%). This creates depth and immersion, making your mix feel larger and more professional. Wide spread on these supporting elements helps them stay out of the way of centered lead elements while still contributing to the overall sonic picture.\n\nBass frequencies are particularly sensitive to stereo spread. Low-frequency information that's too wide causes phase cancellation issues, resulting in weak, thin bass on mono systems (smartphones, club systems, radio). Professional mixes keep bass guitar, kick drum, and sub-bass tightly centered or very narrow (Spread 0-50%). If you want stereo character on bass, apply it only to the midrange and high frequencies while keeping the fundamental frequencies centered.\n\nThe Direction Mixer's Spread control provides smooth, transparent width adjustment, but always verify your changes with mono and phase correlation checks. A correlation meter should show positive values (above zero) for the majority of your mix. Strong negative correlation indicates phase issues that will cause problems in mono playback.\n\nRemember that width creates separation through space, not necessarily through volume. Before reaching for the fader to make something louder, consider whether adjusting its stereo spread would help it fit better in the mix instead.",
+            "symbolName": "arrow.up.left.and.arrow.down.right",
+            "visualTitle": "Spread Comparison",
+            "visualCaption": "Narrow vs wide stereo spread examples.",
+            "settings": {
+              "Narrow (40-80%)": "Samples, loops, make space",
+              "Normal (90-110%)": "Most instruments, default",
+              "Wide (120-150%)": "Pads, atmosphere, depth",
+              "Bass (0-50%)": "Low frequencies, mono compatibility"
+            },
+            "proTip": "Use stereo spread adjustments before panning—sometimes narrowing a source makes it fit perfectly without needing to change its position.",
+            "avoidThis": "Don't widen everything hoping to create a bigger mix—you'll create phase chaos and a weak, thin sound in mono playback.",
+            "checkYourWork": "Your mix has intentional variation in width—some elements are focused and narrow, others are spacious and wide, creating dimension and clarity rather than uniform width.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step5_spread_comparison.png"
+          },
+          {
+            "number": 26,
+            "title": "Mid-Side Processing Fundamentals",
+            "concept": "Mid-side (M/S) processing splits stereo signals into Mid (center mono) and Side (stereo difference) channels, allowing independent processing of center versus wide content.",
+            "actions": [
+              "Understand that Mid contains everything that's identical in left and right channels (center content).",
+              "Understand that Side contains the differences between left and right channels (stereo width information).",
+              "Learn when to process Mid and Side independently for precise stereo control."
+            ],
+            "body": "Mid-side processing is one of the most powerful and versatile stereo techniques available in modern production. Unlike standard left-right stereo, which treats left and right channels as separate entities, mid-side processing reorganizes audio into two conceptually different channels: the Mid channel (center/mono information) and the Side channel (stereo width information).\n\nThe Mid channel contains everything that's identical in both the left and right channels. If you sum the left and right channels together, you get the Mid channel. This is where centered elements live—lead vocals, kick drums, snare drums, bass guitars, and anything else panned to the center. The Mid channel is essentially the mono version of your mix.\n\nThe Side channel contains the differences between the left and right channels. If you subtract the right channel from the left channel, you get the Side channel. This is where stereo width lives—panned instruments, stereo effects, room ambience, and anything that creates the sense of space and width in your mix.\n\nThe magic of mid-side processing is that you can apply completely different processing to the Mid and Side channels independently. Want to add presence to the lead vocal without affecting the wide stereo guitars? Process the Mid channel. Want to brighten the stereo atmosphere without making the centered bass brighter? Process the Side channel.\n\nMid-side thinking opens up countless mixing possibilities: you can EQ the center differently from the sides, compress the center to control lead vocals while leaving sides uncompressed for natural width, add saturation to the sides for excitement without affecting center clarity, or apply different reverb to center versus side content.\n\nLogic Pro's Channel EQ, Stereo Delay, Gain plugin, and several third-party processors offer built-in mid-side modes. The Direction Mixer also has an M/S mode specifically for processing mid-side signals. Understanding mid-side processing fundamentally changes how you think about stereo imaging, moving from simple left-right positioning to sophisticated center-versus-width control.",
+            "symbolName": "arrow.triangle.branch",
+            "visualTitle": "Mid-Side Signal Flow",
+            "visualCaption": "Stereo splits into Mid and Side channels.",
+            "settings": {
+              "Mid Channel": "Center mono content (L+R sum)",
+              "Side Channel": "Stereo width difference (L-R)",
+              "Processing": "Independent EQ, compression, effects per channel"
+            },
+            "proTip": "Use mid-side EQ to remove low frequencies from the Side channel only, keeping bass centered and mono-compatible while maintaining stereo width in higher frequencies.",
+            "avoidThis": "Don't confuse mid-side with left-right—they're different ways of organizing the same stereo information, not competing formats.",
+            "checkYourWork": "You understand that every stereo signal contains both Mid and Side information, and processing them independently gives you precise control over center versus width.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step6_midside_diagram.png"
+          },
+          {
+            "number": 27,
+            "title": "Applying Mid-Side EQ",
+            "concept": "Mid-side EQ allows you to shape the frequency content of centered elements independently from stereo-width elements.",
+            "actions": [
+              "Insert Logic's Channel EQ on a stereo channel or bus.",
+              "Click the M/S button to enable mid-side mode.",
+              "Apply different EQ curves to Mid and Side channels for precise frequency-spatial control."
+            ],
+            "body": "Mid-side EQ is where mid-side processing shows its incredible practical value. Logic Pro's Channel EQ includes a built-in M/S mode that splits the incoming stereo signal into Mid and Side channels, lets you apply completely different EQ curves to each, then recombines them back into standard left-right stereo output.\n\nCommon mid-side EQ applications include controlling bass frequencies independently from width. Since low frequencies should generally be centered for maximum power and mono compatibility, you can apply a high-pass filter to the Side channel (cutting low frequencies from the stereo width) while leaving the Mid channel full-range. This keeps your kick, snare, and bass powerful and centered while maintaining stereo width in the midrange and treble frequencies.\n\nAnother powerful technique is adding presence or air to the center without brightening the sides. If your lead vocal needs more high-frequency presence but your stereo guitars and pads are already bright enough, boost 8-12kHz on the Mid channel only. This brings the vocal forward without making the entire mix sound harsh or overly bright.\n\nYou can also create space by cutting midrange frequencies from the Side channel where your centered lead vocal sits, effectively carving out space in the stereo field for the vocal to occupy. This is like using EQ as a spatial tool rather than just a tonal tool.\n\nMid-side EQ is particularly useful on the master bus or mix bus for final stereo shaping. Gentle boosts in the Side channel high frequencies (10kHz and up) add air and space to the mix without making centered elements harsh. Cutting low-mids (200-500Hz) from the Side channel reduces muddiness in the stereo field while keeping center elements full and present.\n\nWhen using mid-side EQ, always check your changes in mono to ensure you're not creating phase issues or imbalances. Use gentle, musical EQ moves rather than extreme cuts or boosts, and always A/B your processing to verify it's actually improving the mix rather than just making it different.",
+            "symbolName": "slider.horizontal.2.square.on.square",
+            "visualTitle": "Mid-Side EQ Plugin",
+            "visualCaption": "Independent EQ curves for Mid and Side.",
+            "settings": {
+              "Side HPF": "80-120Hz to keep bass centered",
+              "Mid Presence": "3-5kHz boost for vocal clarity",
+              "Side Air": "10kHz+ gentle boost for space",
+              "Side Mud Cut": "200-500Hz reduction for clarity"
+            },
+            "proTip": "Use mid-side EQ on your drum bus to keep kick and snare powerful in the Mid while brightening cymbals and room in the Side channel.",
+            "avoidThis": "Don't apply extreme opposite EQ to Mid and Side—subtle differences create space and clarity; extreme differences create phase issues and strange tonality.",
+            "checkYourWork": "Your mix has clear separation between centered elements and stereo width, and EQ changes affect only the spatial zone you intended to process.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step7_midside_eq.png"
+          },
+          {
+            "number": 28,
+            "title": "The Haas Effect",
+            "concept": "The Haas effect (precedence effect) uses short delays (1-35ms) between left and right channels to create the perception of stereo width from a mono source.",
+            "actions": [
+              "Duplicate a mono track and pan copies hard left and right.",
+              "Apply a short delay (5-20ms) to one side only.",
+              "Verify mono compatibility—Haas effect signals often have phase cancellation in mono."
+            ],
+            "body": "The Haas effect, also called the precedence effect, is a psychoacoustic phenomenon where two identical sounds arriving within approximately 1-35 milliseconds are perceived as a single sound, but with directionality determined by whichever arrives first. This creates the illusion of stereo width from a mono source, making it sound wider and more spacious than simple panning alone.\n\nTo create a Haas effect, duplicate a mono signal onto two tracks or use a delay plugin in stereo mode. Pan one copy hard left and the other hard right. Apply a short delay (typically 10-20 milliseconds) to one side. The result is a wider, more spacious sound than the original mono source, without the need for recording the part twice.\n\nThe Haas effect works because your brain interprets the first-arriving sound as the 'real' source and the delayed sound as a spatial cue or reflection, creating the perception of width and space. The effect is most pronounced with delays between 10-20ms. Shorter delays (1-10ms) create subtle width; longer delays (20-35ms) create more obvious width but start to sound like distinct echoes rather than spatial enhancement.\n\nThe critical limitation of the Haas effect is mono compatibility. When left and right channels are summed to mono (as happens on many playback systems), the timing difference between the delayed and undelayed signals causes comb filtering—a series of phase cancellations that create a hollow, thin tone with missing frequencies. For this reason, Haas effect widening should be used sparingly and primarily on non-critical elements.\n\nBetter alternatives for most situations include: true double-tracking (recording the part twice), stereo recording with multiple microphones, or using less extreme Haas delays (under 10ms) where phase cancellation is less severe. The Haas effect works best on short transient sounds like percussion, effects, or brief vocal phrases where the timing difference adds space without long-term phase issues.\n\nUse the Haas effect as a creative special effect rather than a mixing foundation—save true stereo techniques for core elements that need to sound solid in all playback scenarios.",
+            "symbolName": "waveform.badge.plus",
+            "visualTitle": "Haas Effect Timing",
+            "visualCaption": "Short delay creates perceived width.",
+            "settings": {
+              "Subtle Width": "5-10ms delay",
+              "Moderate Width": "10-20ms delay",
+              "Strong Width": "20-35ms delay (mono issues likely)",
+              "Mono Compatibility": "Comb filtering occurs in mono playback"
+            },
+            "proTip": "If you must use Haas widening on important elements, keep the delay under 10ms and apply a slight low-cut to the delayed side to reduce low-frequency phase issues.",
+            "avoidThis": "Don't use Haas effect on bass, kick, snare, or lead vocals—these elements need solid mono translation, and Haas effect will weaken them significantly in mono playback.",
+            "checkYourWork": "Your Haas-widened elements sound spacious in stereo but check them in mono—if they sound thin, hollow, or weak, reduce the delay time or use a different widening technique.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step8_haas_effect.png"
+          },
+          {
+            "number": 29,
+            "title": "Double Tracking for Natural Width",
+            "concept": "True double tracking—recording the same part twice—creates authentic stereo width without the phase issues of artificial widening techniques.",
+            "actions": [
+              "Record the same part twice on separate tracks with natural performance variations.",
+              "Pan the two takes hard left and hard right or moderate left/right (30-50).",
+              "Accept that small timing and tonal differences create the magic—don't over-align or tune the takes."
+            ],
+            "body": "Double tracking is the gold standard for creating natural, phase-coherent stereo width. Unlike artificial widening techniques that manipulate a single recording, double tracking involves performing the same part twice, recording each performance on a separate track, and panning them left and right. The slight natural variations between the two performances create rich, organic width that translates perfectly to mono.\n\nClassic examples of double tracking include The Beatles' vocal techniques, where John Lennon would sing the same line twice and pan the takes to create a bigger vocal sound. In modern rock and metal production, rhythm guitars are almost always double-tracked (or quad-tracked with two pairs), creating the massive wall of guitars that defines these genres.\n\nThe key to effective double tracking is embracing the natural variations between takes. Small differences in timing, pitch, tone, and dynamics are what create the width and richness. If you over-edit the takes to align them perfectly, you lose the stereo effect and end up with something closer to a mono sound. The goal isn't perfection—it's controlled variation.\n\nFor vocals, double tracking works best on background vocals, harmonies, and gang vocals rather than lead vocals (where a single, centered performance usually sounds more intimate and direct). For guitars, double tracking is essential for rhythm parts and power chords, creating width and power. For acoustic instruments like acoustic guitar or ukulele, double tracking creates a fuller, more produced sound.\n\nThe panning choice affects the character: hard panning (full left and right) creates maximum width and separation, while moderate panning (30-50 degrees) creates a tighter, more cohesive sound that's still noticeably wider than mono. Experiment with different pan positions to find what serves the song and arrangement.\n\nDouble tracking is mono-safe because each performance is genuinely unique. When summed to mono, the takes combine into a single, reinforced sound rather than canceling out like phase-manipulated artificial widening. This makes double tracking the professional choice for any element that needs both stereo width and mono strength.",
+            "symbolName": "person.2.fill",
+            "visualTitle": "Double Tracking Setup",
+            "visualCaption": "Two genuine performances create natural width.",
+            "settings": {
+              "Hard Pan": "L -64, R +63 for maximum width",
+              "Moderate Pan": "L -35, R +35 for cohesion",
+              "Performance": "Natural variations, don't over-align",
+              "Mono Behavior": "Reinforces rather than cancels"
+            },
+            "proTip": "For ultra-wide guitars, record four takes: two panned hard left/right with slightly different tones or amp settings, creating massive stereo width with thickness and dimension.",
+            "avoidThis": "Don't use automatic doubling plugins thinking they'll match real double tracking—the phase relationships are different and won't translate as well to mono.",
+            "checkYourWork": "Your double-tracked elements sound wide and full in stereo, and when checked in mono, they sound reinforced and strong rather than thin or phased.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step9_double_tracking.png"
+          },
+          {
+            "number": 30,
+            "title": "Creative Stereo Delay",
+            "concept": "Logic Pro's Stereo Delay plugin creates rhythmic stereo width using independent left and right delay times, feedback, and crossfeed routing.",
+            "actions": [
+              "Insert Stereo Delay on a channel or send bus.",
+              "Set different delay times for left and right channels to create stereo movement.",
+              "Use crossfeed to send delayed signal from one channel to the other for complex patterns.",
+              "Sync delay times to your project tempo for musical, rhythmic delays."
+            ],
+            "body": "Logic Pro's Stereo Delay is far more than a simple echo effect—it's a sophisticated stereo imaging tool that can create width, movement, rhythm, and space in your mix. Unlike mono delays that create simple repetitions, stereo delays use independent timing for left and right channels to create spatial dimension and rhythmic complexity.\n\nThe fundamental approach is setting different delay times for the left and right channels. For example, a left delay of 1/8 note and a right delay of 1/16 note creates a ping-pong rhythm that bounces between speakers, adding movement and excitement. Tempo-synced delays (set in note values like 1/4, 1/8, 1/16) create musical rhythms that lock with your song, while millisecond-based delays create more subtle spatial effects.\n\nFeedback controls determine how many repetitions each delay produces. Low feedback (10-30%) creates short, subtle delays that add space without drawing attention. High feedback (50-80%) creates longer, more obvious delay tails that can become a rhythmic element in the arrangement. Be careful with feedback above 80%—it can create runaway delays that build infinitely.\n\nCrossfeed is one of Stereo Delay's most powerful features. It routes the delayed left signal to the right delay input (and vice versa), creating complex, interweaving delay patterns that bounce back and forth across the stereo field. This creates much more interesting and musical stereo movement than simple independent left/right delays.\n\nFiltering options (low-pass and high-pass filters) let you shape the tonal character of the delayed signal. A common technique is applying a low-pass filter to cut high frequencies from the delays, making them sit in the background and feel more like reflections or space rather than distinct echoes. This prevents delays from cluttering the mix and competing with dry signals.\n\nFor stereo width enhancement without obvious delays, use very short delay times (20-50ms) with low feedback and mix levels around 15-25%. This creates subtle spatial depth that makes sources feel larger and more three-dimensional without sounding like an obvious delay effect. For creative rhythmic effects, use tempo-synced note values with moderate to high feedback and experiment with crossfeed routing for complex patterns.",
+            "symbolName": "timer",
+            "visualTitle": "Stereo Delay Plugin",
+            "visualCaption": "Independent L/R timing creates movement.",
+            "settings": {
+              "Subtle Space": "20-50ms, 15-25% mix, low feedback",
+              "Rhythmic": "Tempo-synced note values, moderate feedback",
+              "Crossfeed": "50-70% for complex ping-pong patterns",
+              "Filtering": "Low-pass ~3-5kHz for background delays"
+            },
+            "proTip": "Use Stereo Delay on a send bus rather than as an insert so you can process multiple elements with the same delay space, creating cohesion and saving CPU.",
+            "avoidThis": "Don't use extreme feedback values (above 85%) unless you want infinite-building delays—they can quickly overpower your mix and become uncontrollable.",
+            "checkYourWork": "Your delays create stereo width and dimension without cluttering the mix, and rhythmic delays lock musically with your tempo and arrangement.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step10_stereo_delay.png"
+          },
+          {
+            "number": 31,
+            "title": "Monitoring Phase Correlation",
+            "concept": "Phase correlation meters show the phase relationship between left and right channels, helping you identify mono compatibility issues.",
+            "actions": [
+              "Use Logic's Multimeter plugin (Correlation Meter mode) or other phase correlation meters.",
+              "Understand the correlation scale: +1 (mono/in-phase), 0 (decorrelated stereo), -1 (out-of-phase).",
+              "Keep correlation mostly positive (above zero) for solid mono translation."
+            ],
+            "body": "Phase correlation monitoring is essential for ensuring your stereo tricks and widening techniques translate properly to mono playback. A correlation meter displays the phase relationship between left and right channels on a scale from +1 to -1, giving you visual feedback about mono compatibility.\n\nAt +1 (perfectly correlated), the left and right channels are identical—essentially a mono signal. This is what you see on centered, mono sources. It represents maximum mono compatibility but no stereo width.\n\nAt 0 (uncorrelated), the left and right channels contain completely independent information with no phase relationship. This represents natural stereo width created by panning, double tracking, or true stereo recording techniques. Uncorrelated signals maintain their full level when summed to mono.\n\nAt -1 (fully anti-correlated), the left and right channels are identical but inverted in polarity—one is a perfect opposite of the other. This creates maximum apparent stereo width but complete cancellation in mono playback. Negative correlation values indicate phase issues that will cause weak, thin, hollow sound in mono.\n\nProfessional mixes typically show correlation values that bounce between +0.5 and +1.0, occasionally dipping to 0 or slightly negative on specific elements with extreme width, but averaging well into positive territory. If your overall mix correlation spends significant time in negative values, you have phase issues that need attention.\n\nWidening plugins, Haas effect delays, mid-side processing with extreme Side boosts, and certain stereo effects can push correlation into negative territory. Use correlation monitoring while applying these techniques to catch problems before they become mix-ruining issues.\n\nWhen you see negative correlation, identify the source: bypass stereo effects one at a time until correlation improves, check for widening plugins with extreme settings, look for Haas delays that are too long or too loud, and verify that no channels have accidentally inverted polarity.\n\nMonitoring correlation is particularly important on the master bus, drum bus, and any bus where you're applying stereo widening or imaging effects. Catching phase issues during mixing is far easier than trying to fix them after mastering.",
+            "symbolName": "chart.line.uptrend.xyaxis",
+            "visualTitle": "Correlation Meter",
+            "visualCaption": "Monitor phase relationship for mono safety.",
+            "settings": {
+              "+1 (Mono)": "Identical L/R, perfect mono compatibility",
+              "0 (Decorrelated)": "Independent L/R, natural stereo width",
+              "-1 (Anti-phase)": "Inverted L/R, complete mono cancellation",
+              "Target Range": "Mostly +0.3 to +1.0, occasional 0 acceptable"
+            },
+            "proTip": "Set up a key command to toggle the Multimeter plugin's Correlation Meter mode so you can quickly check phase while mixing without opening plugin windows.",
+            "avoidThis": "Don't ignore negative correlation readings thinking 'nobody listens in mono anymore'—phones, Bluetooth speakers, club systems, and radio all sum to mono frequently.",
+            "checkYourWork": "Your correlation meter shows mostly positive values, averaging +0.5 or higher, with only brief excursions into neutral or slightly negative territory on specific wide elements.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step11_correlation_meter.png"
+          },
+          {
+            "number": 32,
+            "title": "Mono Compatibility Checks",
+            "concept": "Regular mono checking during mixing reveals balance issues, phase cancellation, and frequency masking that stereo playback can hide.",
+            "actions": [
+              "Set up a key command or control surface button to toggle mono playback instantly.",
+              "Check mono after every significant stereo adjustment, especially widening and panning changes.",
+              "Verify that essential elements (kick, snare, bass, lead vocal) remain strong in mono."
+            ],
+            "body": "Checking your mix in mono is one of the most revealing and important quality control steps in the mixing process. Mono playback exposes problems that stereo monitoring can mask, ensuring your mix translates to all playback systems including smartphones, mono Bluetooth speakers, club systems, broadcast, and any situation where stereo channels are summed to mono.\n\nMono checking reveals level balance issues. Elements that seem present and clear in stereo may completely disappear or become too loud in mono, indicating that their level balance depends on stereo positioning rather than actual volume. A well-balanced mix should maintain its core balance and hierarchy in mono, even if it sounds slightly less spacious or exciting.\n\nPhase cancellation becomes immediately obvious in mono. Stereo widening techniques, Haas delays, out-of-phase recordings, and certain stereo effects that sound impressive in stereo can cause elements to thin out, become hollow, or partially disappear in mono. If something sounds great in stereo but weak or strange in mono, you have a phase issue that needs correction.\n\nFrequency masking is easier to identify in mono. When panned elements collapse to center in mono playback, instruments that occupied different stereo positions now directly compete in the same space. If your mix becomes muddy, cluttered, or loses clarity in mono, it indicates that you've relied too heavily on stereo separation and need to create separation through EQ, level balance, or arrangement instead.\n\nProfessional engineers often build their initial rough balance in mono or toggle frequently between mono and stereo while mixing. This forces you to make separation through proper gain staging, EQ, and depth (reverb/delay) rather than relying solely on stereo positioning as a crutch.\n\nTo set up effective mono monitoring in Logic, assign a key command to 'Mono' under the Metering section, or use the mono button on your audio interface if available. Make toggling to mono a single keystroke or button press so you check frequently without breaking your workflow. Check mono especially after applying stereo widening, adjusting panning, adding delays or reverbs, and before finalizing any mix.",
+            "symbolName": "speaker.fill",
+            "visualTitle": "Mono Check Workflow",
+            "visualCaption": "Toggle mono to verify balance and compatibility.",
+            "settings": {
+              "Key Command": "Assign for instant mono toggle",
+              "Check Frequency": "After every stereo adjustment",
+              "Essential Elements": "Kick, snare, bass, lead vocal must stay strong",
+              "Problem Signs": "Disappearing elements, thin sound, muddy low-end"
+            },
+            "proTip": "Do a full playthrough of your mix in mono at least once before finalizing—you'll discover balance and clarity issues you'd never catch in stereo-only monitoring.",
+            "avoidThis": "Don't only check mono at the very end of mixing—by then, fixing phase and balance issues requires major changes. Check mono throughout the process.",
+            "checkYourWork": "Your mix maintains its core balance, energy, and clarity in mono, with only a natural reduction in spaciousness and width compared to stereo playback.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step12_mono_check.png"
+          },
+          {
+            "number": 33,
+            "title": "Frequency-Dependent Stereo: Split Mode",
+            "concept": "Direction Mixer's Split mode allows different stereo spread settings for separate frequency ranges, ideal for keeping bass centered while widening highs.",
+            "actions": [
+              "Insert Direction Mixer and select Split mode.",
+              "Set the crossover frequency (typically 120-250Hz) to separate low and high frequencies.",
+              "Apply narrow spread to low frequencies and wider spread to high frequencies."
+            ],
+            "body": "Frequency-dependent stereo processing is one of the most professional and sophisticated stereo techniques available. Direction Mixer's Split mode divides the incoming signal into two frequency bands using a crossover point you define, then applies independent stereo spread settings to each band. This solves one of mixing's most common problems: wanting stereo width in the highs while keeping bass frequencies centered and mono-compatible.\n\nThe typical application is setting the crossover between 100-250Hz (depending on the source material), applying narrow spread (0-30%) to the low band to keep bass centered and powerful, and applying wider spread (120-150%) to the high band to create space and dimension in the midrange and treble frequencies. This gives you the best of both worlds: solid, mono-compatible low end and spacious, immersive high end.\n\nSplit mode is particularly effective on full mixes, master bus processing, and instrument buses like a drum bus. On a drum bus, you can keep the kick and low-end of the snare centered and punchy while widening the cymbals, overheads, and room mics for a natural, spacious drum sound that still hits hard in mono.\n\nOn stereo synth pads and keyboards, Split mode lets you keep the fundamental frequencies (where the weight and power lives) focused in the center while spreading the harmonics and high-frequency shimmer wide across the stereo field. This prevents the pads from becoming too diffuse or weak while still creating atmospheric width.\n\nThe crossover frequency choice depends on the source material. For bass-heavy sources, set the crossover lower (80-120Hz) to keep only the deep sub-bass centered. For midrange-focused sources, set the crossover higher (200-300Hz) to keep more of the fundamental centered. Use your ears and a spectrum analyzer to identify where the source's energy is concentrated.\n\nSplit mode avoids the phase issues and mono compatibility problems of full-spectrum widening because the low frequencies—where phase issues are most problematic and where mono compatibility matters most—remain narrow or centered. Only the high frequencies, which are more phase-tolerant and less critical for mono translation, receive width processing.\n\nThis technique is standard in professional mastering and is increasingly common in mixing for creating modern, wide, immersive mixes that still sound powerful and focused on all playback systems.",
+            "symbolName": "waveform.path",
+            "visualTitle": "Split Mode Processing",
+            "visualCaption": "Independent width control per frequency band.",
+            "settings": {
+              "Crossover": "100-250Hz (adjust to source)",
+              "Low Band Spread": "0-30% (keep bass centered)",
+              "High Band Spread": "120-150% (widen mids/highs)",
+              "Applications": "Master bus, drum bus, synth pads, keyboards"
+            },
+            "proTip": "Use Split mode on your master bus with subtle settings (crossover 120Hz, low spread 10%, high spread 110%) for gentle, professional stereo enhancement that's completely mono-safe.",
+            "avoidThis": "Don't set the crossover too high (above 300Hz)—you'll narrow too much of the frequency spectrum and make your mix sound thin or disconnected.",
+            "checkYourWork": "Your low end feels powerful and centered in both stereo and mono, while your midrange and highs feel spacious and wide without phase issues.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step13_split_mode.png"
+          },
+          {
+            "number": 34,
+            "title": "Binaural Panner Basics",
+            "concept": "Logic's Binaural Panner uses head-related transfer functions (HRTF) to create 3D spatial positioning for headphone playback, placing sounds anywhere in 3D space.",
+            "actions": [
+              "Insert Binaural Panner on any mono or stereo channel.",
+              "Adjust azimuth (left-right position), elevation (up-down position), and distance.",
+              "Mix in headphones to experience the full 3D effect—Binaural Panner is optimized for headphone playback."
+            ],
+            "body": "Binaural panning represents the cutting edge of spatial audio for headphones. Unlike traditional stereo panning that creates a left-right soundstage between speakers, binaural processing uses head-related transfer functions (HRTF) to simulate how your ears perceive sound in three-dimensional space, creating the illusion of sounds appearing above, below, behind, and in front of you, not just left and right.\n\nThe technology works by modeling how sound waves interact with your head, ears, and upper body before reaching your eardrums. When a sound comes from behind you in real life, it sounds different than when it comes from in front because your head and outer ears (pinnae) filter and delay the sound waves differently depending on the source direction. Binaural panning recreates these cues digitally.\n\nLogic's Binaural Panner interface presents a sphere where you can position sounds anywhere in 3D space. Azimuth controls left-right positioning (traditional stereo panning), elevation controls up-down positioning, and distance controls how close or far the sound appears. Moving a sound source around the sphere in real-time creates incredibly realistic 3D motion effects.\n\nBinaural panning is primarily effective for headphone playback—the effect is much less pronounced on speakers because real speaker positioning creates its own spatial cues that can conflict with the binaural processing. This makes binaural panning ideal for podcast production, game audio, VR/AR content, meditation and relaxation tracks, and any content primarily consumed on headphones.\n\nFor music mixing, binaural panning can add unique spatial character to specific elements like background vocals (placed above or behind), effects and atmospheres (placed in unusual positions for surreal effects), or transitional elements (panned around the listener's head for dramatic movement). However, traditional stereo panning remains more practical for most music mixing since music is consumed on both speakers and headphones.\n\nWhen using Binaural Panner for music, apply it to supporting elements rather than core elements like lead vocals, kick, and bass. The 3D positioning can make sources feel disconnected from the main mix if overused. Subtle binaural positioning on pads, effects, and background elements creates immersive depth while keeping the foundation traditional and solid.\n\nAlways check how binaural-panned mixes translate to speakers—while they won't collapse completely, the 3D effect will be reduced, so verify your mix still works in both playback scenarios.",
+            "symbolName": "rotate.3d",
+            "visualTitle": "Binaural Panner Interface",
+            "visualCaption": "3D sound positioning for headphones.",
+            "settings": {
+              "Azimuth": "Left-right position (traditional stereo)",
+              "Elevation": "Up-down position (3D space)",
+              "Distance": "Near-far position (depth)",
+              "Best For": "Headphone-consumed content (podcasts, games, VR)"
+            },
+            "proTip": "For dramatic intro or transition effects, automate Binaural Panner position to move sounds around the listener's head in circular or spiral patterns—incredibly effective on headphones.",
+            "avoidThis": "Don't use Binaural Panner on every element thinking it will make everything 3D—overuse creates a disorienting mix that doesn't translate to speakers. Use selectively for special impact.",
+            "checkYourWork": "On headphones, your binaural-panned elements appear convincingly positioned in 3D space; on speakers, the mix still sounds coherent and balanced even if the 3D effect is reduced.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step14_binaural_panner.png"
+          },
+          {
+            "number": 35,
+            "title": "Stereo Width Zones by Instrument",
+            "concept": "Different instrument types benefit from different stereo width treatments based on their frequency content, role in the arrangement, and mono compatibility needs.",
+            "actions": [
+              "Keep foundational low-frequency instruments (kick, bass, sub-bass) centered or very narrow.",
+              "Use moderate width on rhythm instruments (guitars, keys) for balance.",
+              "Apply wide spread on atmospheric elements (pads, effects, backgrounds) for depth.",
+              "Verify each width decision in mono to ensure appropriate translation."
+            ],
+            "body": "Strategic stereo width assignment by instrument type is a hallmark of professional mixing. Not all instruments should be treated equally in terms of stereo spread—each instrument's frequency content, arrangement role, and importance determines its optimal width treatment.\n\nFoundational low-frequency instruments must stay centered or very narrow (spread 0-20%). This category includes kick drum, bass guitar, sub-bass synths, and the fundamental frequencies of snare drum. Low frequencies are non-directional in human hearing and contain the most energy, making them prone to phase issues if spread wide. Keeping them centered ensures maximum impact and perfect mono compatibility.\n\nRhythm and supporting instruments work well with moderate width (spread 80-120%). This includes rhythm electric guitars, acoustic guitars, piano, organ, synth chords, and supporting vocal harmonies. These elements benefit from some stereo character to create space and separation from centered elements, but don't need extreme width since they serve a supporting role rather than an atmospheric one.\n\nAtmospheric and background elements can take wide spread (spread 130-160%). This category includes string pads, synth pads, ambient textures, reverb returns, stereo delays, background 'ooh-aah' vocals, and sound effects. Wide spread pushes these elements to the edges of the stereo field, creating space and depth while keeping the center clear for lead elements.\n\nLead instruments and vocals typically stay centered (spread 90-110%) or just slightly wide. This includes lead vocals, lead guitar solos, lead synth melodies, and primary melodic instruments. These elements need maximum focus and impact, which comes from center positioning. Slight width (100-110%) can add polish without sacrificing focus.\n\nPercussion requires frequency-dependent treatment. Shakers, tambourines, and high-frequency percussion can be wide (spread 120-140%) to add excitement and movement. Hand drums, congas, and toms should be moderate (spread 80-100%) to maintain weight and focus. Kick and snare must stay centered as previously mentioned.\n\nThis width-by-instrument approach creates a natural depth hierarchy: bass and drums provide a solid, centered foundation; rhythm instruments create a supportive layer with moderate width; atmospheric elements fill the outer edges with spacious depth; and lead elements command attention from the powerful center position. This is the architecture of professional, three-dimensional mixes.",
+            "symbolName": "chart.bar.fill",
+            "visualTitle": "Width Zones by Instrument",
+            "visualCaption": "Strategic width assignment for clarity and depth.",
+            "settings": {
+              "Bass/Kick (0-20%)": "Centered foundation, mono-safe",
+              "Rhythm (80-120%)": "Moderate width, supporting role",
+              "Atmosphere (130-160%)": "Wide depth, background space",
+              "Lead (90-110%)": "Focused center, maximum impact",
+              "Percussion (varies)": "High perc wide, low perc moderate"
+            },
+            "proTip": "Draw a simple chart showing your stereo field from center to wide edges, then assign each instrument in your mix to a zone—this helps you visualize and balance width before mixing.",
+            "avoidThis": "Don't give everything the same width treatment thinking consistency is professional—intentional width variation creates the depth and dimension that separates amateur from pro mixes.",
+            "checkYourWork": "Your mix has clear width zones with centered foundation, moderate rhythm support, and wide atmospheric depth, creating three-dimensional space without cluttering or phase issues.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step15_width_zones.png"
+          },
+          {
+            "number": 36,
+            "title": "Identifying and Fixing Phase Cancellation",
+            "concept": "Phase cancellation occurs when left and right channels contain similar signals with opposite polarity, causing frequency loss and weak mono translation.",
+            "actions": [
+              "Use correlation meters to identify negative correlation (phase issues).",
+              "Check for inverted polarity on channels—flip polarity if one channel is accidentally inverted.",
+              "Reduce stereo widening effects, especially Haas delays and extreme spreading.",
+              "Replace artificial widening with true stereo techniques like double tracking."
+            ],
+            "body": "Phase cancellation is one of the most common and destructive problems in modern mixing, particularly as more producers use stereo widening plugins and effects without understanding the consequences. When similar audio signals with opposite polarity combine, they cancel each other out, creating frequency gaps, thin sound, and weak mono translation that can ruin an otherwise great mix.\n\nPhase cancellation happens in several common scenarios: Haas effect delays where the delayed signal's polarity is inverted or partially inverted; stereo widening plugins that use polarity inversion or mid-side manipulation with extreme settings; accidentally inverted polarity on one channel of a stereo recording; close-miked instruments where phase relationships between multiple mics cause cancellation; and mid-side processing with extreme Side boosts that create unnaturally wide, out-of-phase signals.\n\nThe symptoms of phase cancellation include: thin, hollow, or 'phasey' tone; weak low end even though the source has bass content; elements that disappear or become much quieter in mono playback; correlation meters showing negative values; and frequency analyzer showing obvious gaps or notches in the spectrum.\n\nTo fix phase cancellation, first identify the problem source. Solo individual channels or buses while watching a correlation meter—when correlation goes negative, you've found the problem. Check for inverted polarity by selecting the channel and looking for a polarity flip button (Ø symbol). If one channel of a stereo pair has inverted polarity, flip it back to normal.\n\nReduce or bypass stereo widening effects one at a time to see which is causing phase issues. Haas delays longer than 15ms are particularly problematic—shorten the delay time or reduce the wet/dry mix. Stereo widening plugins with 'width' parameters above 150% often cause phase issues—reduce the width to more moderate settings.\n\nFor stereo recordings with inherent phase issues, try inverting the polarity of one channel to see if the sound becomes fuller and stronger. This is common with drum overheads, stereo guitar mics, and room mics where mic placement causes phase interference.\n\nThe best solution is prevention: use true stereo techniques like double tracking instead of artificial widening; keep Haas delays under 10ms or avoid them on important elements; monitor correlation throughout mixing; and always verify your stereo tricks in mono playback before committing to them.",
+            "symbolName": "exclamationmark.triangle.fill",
+            "visualTitle": "Phase Cancellation Warning",
+            "visualCaption": "Identifying and fixing phase issues.",
+            "settings": {
+              "Correlation": "Negative values indicate phase problems",
+              "Polarity Check": "Verify no channels have inverted polarity",
+              "Widening Reduction": "Lower spread/width settings on plugins",
+              "Haas Limit": "Keep delays under 10ms for mono-safe width"
+            },
+            "proTip": "Use the 'Check Phase' technique: if making something wider makes it sound bigger in stereo but weaker in mono, you've created phase issues—back off the widening.",
+            "avoidThis": "Don't ignore phase correlation meters or skip mono checks—these are your early warning system for phase problems that will ruin your mix translation.",
+            "checkYourWork": "Your correlation meter shows mostly positive values, your mix sounds full and strong in both stereo and mono, and widened elements maintain their body and impact in mono playback.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step16_phase_cancellation.png"
+          },
+          {
+            "number": 37,
+            "title": "Stereo Imaging Plugin Chain",
+            "concept": "Proper signal flow order for stereo processing plugins affects the final stereo image quality—position, then width, then spatial effects.",
+            "actions": [
+              "Position first: Use Direction Mixer or pan controls to set the center position.",
+              "Width second: Adjust stereo spread with Direction Mixer Spread control.",
+              "Spatial effects last: Add stereo delays, reverbs, and modulation effects after positioning and width."
+            ],
+            "body": "The order in which you apply stereo processing significantly affects the final stereo image quality and character. Understanding proper signal flow for stereo imaging plugins ensures clean, professional results without unwanted artifacts or processing conflicts.\n\nThe general rule is: position first, then width, then spatial effects. This order mirrors how you'd approach stereo imaging conceptually—decide where an element sits in the field, then how much space it occupies, then what kind of environmental character it has.\n\nPosition (Direction Mixer Direction knob, or pan controls) determines the center point of your stereo image. This is the foundation—where in the left-right field does this element live? Process this first because width and spatial effects build on this placement. If you widen a sound first then rotate it, you may get unexpected results as the widening algorithm wasn't designed to operate on rotated signals.\n\nWidth (Direction Mixer Spread control, stereo imagers) determines how much of the stereo field the element occupies. Apply width processing after positioning but before spatial effects. Width affects the direct sound character and should be established before adding environmental effects that further interact with the stereo image.\n\nSpatial effects (reverb, delay, chorus, flanger) add depth, space, and movement. These process the already-positioned, already-widened signal to place it in an environment or create modulation. Spatial effects often generate their own stereo image, which should build on your intentional positioning and width decisions rather than competing with them.\n\nEQ and dynamics processing (compression, saturation) typically come before stereo imaging in the signal chain. You want to shape the tone and dynamics of the source before manipulating its stereo characteristics, as EQ and compression can subtly affect phase relationships that stereo processing then builds upon.\n\nA typical professional stereo imaging signal chain looks like: Input → EQ → Compression → Direction Mixer (position + width) → Stereo Delay → Reverb → Output. This creates tonal balance, dynamic control, intentional stereo imaging, and then environmental character in that logical order.\n\nFor mid-side processing, the order is slightly different: Input → EQ (possibly mid-side) → Compression → Mid-Side Processor → Spatial Effects → Output, since mid-side processing affects both position and width simultaneously.",
+            "symbolName": "arrow.right.to.line.alt",
+            "visualTitle": "Stereo Plugin Chain",
+            "visualCaption": "Signal flow: position, width, spatial effects.",
+            "settings": {
+              "Position (First)": "Direction Mixer Direction, pan controls",
+              "Width (Second)": "Direction Mixer Spread, imagers",
+              "Spatial (Third)": "Reverb, delay, modulation",
+              "Before All": "EQ, compression, dynamics"
+            },
+            "proTip": "Save your go-to stereo imaging chain as a channel strip preset so you can instantly recall it on any channel that needs professional stereo treatment.",
+            "avoidThis": "Don't randomly insert stereo processors in any order—processing order matters for stereo imaging, and wrong order creates unpredictable artifacts.",
+            "checkYourWork": "Your stereo-processed elements have clear, intentional positioning, appropriate width, and cohesive spatial character without conflicts or artifacts between processors.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step17_stereo_chain.png"
+          },
+          {
+            "number": 38,
+            "title": "Common Stereo Mistakes",
+            "concept": "Avoiding common stereo imaging mistakes prevents weak mixes, phase issues, and translation problems across different playback systems.",
+            "actions": [
+              "Don't widen bass frequencies—keep low-end centered or narrow.",
+              "Don't pan everything to extremes—maintain center content for focus.",
+              "Don't use excessive Haas delays—they cause severe mono cancellation.",
+              "Don't skip mono checking—catch phase issues before finalizing."
+            ],
+            "body": "Even experienced mixers fall into common stereo imaging traps that compromise mix quality, mono compatibility, and professional translation. Understanding these mistakes helps you avoid them and create mixes that sound great on all playback systems.\n\nMistake #1: Over-widening bass frequencies. Bass frequencies below 100Hz should almost never be widened. They're non-directional in human hearing, contain massive energy, and cause severe phase cancellation in mono when spread wide. Wide bass sounds impressive on high-end studio monitors but disappears on phones, Bluetooth speakers, and club systems. Keep kick, bass guitar, and sub-bass centered or very narrow (spread 0-20%). If you want stereo character on bass instruments, apply it only to midrange and high harmonics using frequency-dependent processing (Split mode).\n\nMistake #2: Panning everything to extremes. Beginners often hard-pan everything left or right thinking maximum separation creates the best mix, leaving the center empty except for vocals. This creates a weak, hollow, disconnected mix with no focal point. Professional mixes maintain strong center content (kick, snare, bass, lead vocal, lead instruments) with moderate panning for supporting elements and wide positioning only for atmospheric parts.\n\nMistake #3: Excessive Haas delays. The Haas effect creates apparent width but at the cost of severe phase cancellation in mono. Delays longer than 15-20ms create obvious comb filtering when summed to mono, making sources sound thin, hollow, and weak. If you must use Haas effect widening, keep delays under 10ms and apply it only to non-essential elements, never to bass, drums, or lead vocals.\n\nMistake #4: No mono checking. Many producers mix entirely in stereo, never checking mono compatibility until mastering or worse, after release. Mono playback is still extremely common (phones, Bluetooth speakers, club systems, broadcast), and phase issues that sound fine in stereo destroy mixes in mono. Toggle to mono frequently throughout mixing, especially after any stereo widening or positioning changes.\n\nMistake #5: Artificial widening instead of true stereo techniques. Widening plugins are tempting shortcuts, but they manipulate phase relationships in ways that often cause mono issues. True stereo techniques like double tracking, stereo recording with multiple mics, and natural panning create authentic width that translates perfectly to mono. Use artificial widening sparingly on non-critical elements only.\n\nMistake #6: Ignoring correlation meters. Negative correlation values indicate out-of-phase signals that will cause problems, but many producers don't monitor correlation. Use a correlation meter on your master bus and check it regularly—mostly positive values (+0.3 to +1.0) indicate healthy stereo that will translate well.\n\nMistake #7: Extreme mid-side processing. Mid-side EQ and dynamics are powerful, but extreme settings (massive Side boosts, Mid scooping) create unnatural, phase-problematic results. Use mid-side processing with restraint and musicality, not as an extreme special effect.\n\nAvoiding these mistakes ensures your stereo imaging enhances your mix rather than compromising it, creating professional translations across all playback systems.",
+            "symbolName": "xmark.circle.fill",
+            "visualTitle": "Common Stereo Mistakes",
+            "visualCaption": "Avoid these critical stereo imaging errors.",
+            "settings": {
+              "Wide Bass": "Never—keep bass centered or narrow",
+              "Extreme Panning": "Avoid—maintain strong center content",
+              "Long Haas Delays": "Risky—keep under 10ms or avoid",
+              "No Mono Check": "Critical mistake—check mono frequently",
+              "Artificial Widening": "Sparingly—prefer true stereo techniques",
+              "Negative Correlation": "Problem—keep correlation positive",
+              "Extreme M/S": "Careful—use moderate, musical settings"
+            },
+            "proTip": "Create a pre-mastering checklist that includes mono playback, correlation meter check, and bass frequency width verification—catch stereo mistakes before they become release problems.",
+            "avoidThis": "Don't chase 'the widest mix possible' as a goal—chase clarity, balance, and solid translation instead. Width is a tool for those goals, not the goal itself.",
+            "checkYourWork": "Your bass is centered and powerful, your stereo field is balanced with strong center content, your correlation stays mostly positive, and your mix sounds great in both mono and stereo playback.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step18_common_mistakes.png"
+          },
+          {
+            "number": 39,
+            "title": "Professional Stereo Workflow",
+            "concept": "A systematic stereo imaging workflow ensures consistent, professional results and prevents costly mixing mistakes.",
+            "actions": [
+              "Step 1: Build initial balance in mono to establish solid foundation.",
+              "Step 2: Add panning for spatial separation while maintaining center strength.",
+              "Step 3: Apply width enhancements to supporting and atmospheric elements.",
+              "Step 4: Check phase correlation and verify mono compatibility.",
+              "Step 5: Make final stereo adjustments based on translation tests.",
+              "Step 6: Document stereo decisions for recall and consistency."
+            ],
+            "body": "Professional mixers follow systematic workflows that ensure consistent results and catch problems before they become disasters. A structured stereo imaging workflow prevents the common pitfalls of random, reactive mixing and creates mixes that translate beautifully to all playback systems.\n\nStep 1: Build initial balance in mono. Start your mix with the master bus switched to mono, or build your rough balance before adding any stereo processing. This forces you to create separation through volume, EQ, and depth (reverb) rather than relying on stereo positioning as a crutch. Elements that work in mono will always work in stereo, but the reverse isn't true.\n\nStep 2: Add panning for spatial separation. Once your mono balance is solid, switch to stereo and add panning to create spatial separation. Keep foundational elements (kick, snare, bass, lead vocal) centered. Pan rhythm and supporting elements to moderate positions (30-50 degrees). Reserve wide positions (60-90 degrees) for atmospheric and background elements. Check mono after major panning changes to verify nothing disappeared.\n\nStep 3: Apply width enhancements to supporting and atmospheric elements. With panning established, add stereo width processing to elements that benefit from it: widen pads and atmospheres with Direction Mixer or mid-side processing, add stereo delays for spatial depth, narrow overly-wide samples to create space in the mix. Keep bass frequencies centered using frequency-dependent processing (Split mode) when widening full-spectrum sources.\n\nStep 4: Check phase correlation and verify mono compatibility. Open a correlation meter on your master bus and check that your mix shows mostly positive correlation (+0.3 to +1.0), with only brief excursions to neutral or slightly negative. Toggle to mono and listen critically—all essential elements should remain strong and present, the balance should be maintained, and nothing should sound thin, hollow, or weird. If problems appear, identify and fix the source.\n\nStep 5: Make final stereo adjustments based on translation tests. Listen to your mix on multiple playback systems: studio monitors, headphones, phone speakers, car stereo, Bluetooth speakers. Identify any translation issues and make corrective stereo adjustments. Does the bass hold up on small speakers (indicating good mono compatibility)? Do wide elements feel cohesive or disconnected? Does the mix maintain its balance across systems?\n\nStep 6: Document stereo decisions for recall and consistency. Note your stereo imaging choices in project documentation: pan positions for key elements, width settings, mid-side processing approaches, and any special stereo techniques used. This ensures you can recall your approach when revisiting the project, maintain consistency across songs in an album or EP, and learn from what worked or didn't work.\n\nThis workflow creates professional stereo imaging systematically, catching problems early when they're easy to fix, and ensuring your mix translates well to all playback scenarios.",
+            "symbolName": "checklist",
+            "visualTitle": "Professional Stereo Workflow",
+            "visualCaption": "Systematic approach ensures consistent results.",
+            "settings": {
+              "Step 1": "Build in mono—solid foundation",
+              "Step 2": "Add panning—spatial separation",
+              "Step 3": "Enhance width—atmosphere and depth",
+              "Step 4": "Check phase—correlation and mono",
+              "Step 5": "Test translation—multiple systems",
+              "Step 6": "Document—recall and consistency"
+            },
+            "proTip": "Create a custom project template with your stereo workflow built in: mono reference channels, correlation meters pre-routed, key commands assigned, and documentation notes ready to fill in.",
+            "avoidThis": "Don't mix reactively, randomly adding stereo effects and widening whenever something doesn't sound good enough—follow a systematic workflow for predictable, professional results.",
+            "checkYourWork": "You've followed each workflow step, documented your stereo decisions, verified mono compatibility and phase correlation, and tested translation on multiple playback systems before finalizing your mix.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step19_workflow.png"
+          },
+          {
+            "number": 40,
+            "title": "Stereo Automation for Dynamic Width",
+            "concept": "Automating stereo width throughout your mix creates dynamic, engaging productions with width that changes intentionally for musical impact.",
+            "actions": [
+              "Identify section-based width changes: narrow verses for intimacy, wide choruses for impact.",
+              "Automate Direction Mixer Spread for smooth width transitions.",
+              "Create build-ups by gradually widening from narrow to maximum width.",
+              "Use automation for special effects like width ducking or width swells."
+            ],
+            "body": "Static stereo width throughout an entire song is a missed opportunity for creating dynamic, engaging, professional productions. Automating stereo width creates intentional contrast between sections, builds energy for choruses and drops, and adds movement and excitement that static mixing can't achieve.\n\nSection-based width automation is the foundation technique. Verses often benefit from slightly narrower width (spread 80-100%) to create intimacy and focus on lyrics and melody. Pre-choruses can gradually widen to build anticipation. Choruses explode with wider settings (spread 120-140%) to create impact, energy, and release. Bridges might return to narrow or moderate width to create contrast and reset energy before the final chorus.\n\nDirection Mixer Spread is ideal for automation because it smoothly adjusts stereo width without clicks or artifacts. Draw automation curves that gradually widen from verse to chorus over 2-4 bars, creating a natural build. Avoid instant width jumps (which sound unnatural and jarring) in favor of smooth transitions that the listener feels subconsciously rather than noticing overtly.\n\nBuild-ups use width automation for dramatic effect. Start a build section at narrow width (spread 40-60%), gradually increase to normal width (100%) through the build, then explode to maximum width (140-150%) on the drop or chorus downbeat. Combined with volume, filter, and reverb automation, width automation intensifies the build and maximizes impact on the drop.\n\nSpecial effects include: width ducking (briefly narrowing width on kick hits for pumping effect), width swells (sweeping from narrow to wide and back on transitions or fills), call-and-response width (alternating between narrow and wide on different phrases), and breakdown width reduction (collapsing to near-mono in breakdowns for maximum contrast when full width returns).\n\nOn background vocals and harmonies, automate width to follow the lead vocal's intensity—narrow during intimate lead vocal phrases, widening when the lead vocal gets powerful to create supportive bigness. On synth pads and atmospheres, automate width to create movement and interest without changing pitch or filter settings.\n\nAlways check width automation moves in mono to ensure no phase issues occur at any automation point. Some width settings may sound great at one value but cause problems at another, so test the full range. Use correlation meters while playing back automated sections to verify you're not creating phase problems at peak width values.\n\nWidth automation is a professional technique that separates amateur static mixes from dynamic, engaging professional productions. It's subtle enough that listeners don't consciously notice it, but powerful enough that they feel the energy, contrast, and movement it creates.",
+            "symbolName": "waveform.path.badge.plus",
+            "visualTitle": "Stereo Width Automation",
+            "visualCaption": "Dynamic width creates energy and contrast.",
+            "settings": {
+              "Verse": "Narrow (80-100%) for intimacy",
+              "Pre-Chorus": "Gradual widen to build anticipation",
+              "Chorus": "Wide (120-140%) for impact",
+              "Build-Up": "40% → 100% → 150% on drop",
+              "Breakdown": "Near-mono for contrast",
+              "Transition Length": "2-4 bars for smooth, natural feel"
+            },
+            "proTip": "Automate width on your drum bus to make choruses feel bigger—narrow slightly in verses (90%), widen in choruses (110%)—subtle but effective for creating section contrast.",
+            "avoidThis": "Don't automate width on bass frequencies or core elements—width automation works best on pads, atmospheres, background vocals, and supporting elements, not foundation elements.",
+            "checkYourWork": "Your width automation creates noticeable energy and contrast between sections, transitions smoothly without artifacts, and maintains mono compatibility at all automation points.",
+            "stepScreenshot": "/assets/training/stereo-tricks/step22_stereo_automation.png"
+          },
+          {
+            "number": 41,
+            "title": "Understanding Sidechaining Fundamentals",
+            "concept": "Sidechaining uses one audio signal to control the behavior of a processor on another track, creating dynamic space and movement in your mix.",
+            "actions": [
+              "Learn the signal flow: source track (trigger) controls processor on target track (affected).",
+              "Understand the difference between transparent mixing sidechaining and creative effect sidechaining.",
+              "Identify which Logic Pro plugins support sidechain input."
+            ],
+            "body": "Sidechaining is a routing technique where one audio signal—the 'trigger' or 'key' signal—controls a processor on a different track. The most common application is sidechain compression, but Logic Pro supports sidechaining with compressors, gates, auto-filters, and several synthesizers.\n\nThe fundamental concept is this: instead of a processor responding to the audio on its own track, it responds to audio from somewhere else. When a kick drum plays, sidechain compression on the bass track 'hears' that kick and compresses the bass at that moment, creating space for the kick to cut through.\n\nThere are two broad philosophical approaches to sidechaining:\n\n**Transparent Sidechaining (Mixing):** The goal is clarity and space without obvious artifacts. You want elements to coexist without frequency masking, but you don't want listeners to consciously notice the ducking. This is common in professional pop, rock, hip-hop, and film mixing. Settings are gentle: low ratios (2:1 to 4:1), moderate attack, release timed to musical phrases.\n\n**Creative Sidechaining (Production):** The ducking effect is deliberate and obvious, often rhythmic and exaggerated. This is the 'pumping' sound in EDM, French house, and modern pop. Settings are aggressive: high ratios (8:1 to ∞:1), fast attack, release synchronized to tempo. The effect becomes part of the arrangement's character.\n\nIn Logic Pro, the following plugins support sidechain input:\n- Compressor (all types including Vintage models)\n- Noise Gate\n- Expander\n- Auto Filter\n- Enveloper\n- EVOC 20 TrackOscillator\n- ES2, Sculpture, and EVOC 20 PolySynth (for synthesis applications)\n\nThird-party plugins like FabFilter Pro-C 2, FabFilter Pro-Q 3 (dynamic EQ), Trackspacer, Soothe 2, and Waves C1 also offer advanced sidechain features, though Logic's stock tools are fully capable for most tasks.\n\nThe sidechaining workflow always follows this pattern:\n1. Place the processor (compressor, gate, etc.) on the track you want to affect (target).\n2. In the processor's interface, locate the Sidechain or 'Side Chain' menu (usually top-right corner).\n3. Select the track or bus you want to use as the trigger source.\n4. Adjust the processor's parameters to achieve your desired response.\n\nSidechaining is one of the most powerful tools in modern mixing and production. It solves frequency masking problems, creates space for vocals and lead elements, automates dynamic changes that would be tedious to write manually, and generates creative rhythmic movement. Understanding when and how to apply it separates amateur mixes from professional ones.",
+            "symbolName": "point.3.filled.connected.trianglepath.dotted",
+            "visualTitle": "Sidechain Signal Flow",
+            "visualCaption": "Source signal controls target processor.",
+            "settings": {
+              "Transparent Settings": "Ratio 2:1-4:1, moderate attack/release",
+              "Creative Settings": "Ratio 8:1+, fast attack, tempo-synced release",
+              "Supported Plugins": "Compressor, Gate, Auto Filter, and more"
+            },
+            "proTip": "When learning sidechaining, start with obvious, exaggerated settings so you can clearly hear what's happening. Once you understand the behavior, dial back the intensity for transparent mixing results.",
+            "avoidThis": "Don't apply sidechaining to every track by default. Use it to solve specific problems or create intentional effects—overuse creates an unstable, pumping mix where nothing feels anchored.",
+            "checkYourWork": "You can explain the signal flow of sidechaining and identify which track is the trigger and which is the target.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step1_sidechain_concept.png"
+          },
+          {
+            "number": 42,
+            "title": "Classic Application: Kick-Bass Ducking",
+            "concept": "Sidechaining bass to kick drum creates low-end clarity by temporarily reducing bass volume when the kick hits, preventing frequency masking in the 40-80Hz range.",
+            "actions": [
+              "Place a compressor on your bass track.",
+              "Set the compressor's sidechain input to your kick drum track.",
+              "Use fast attack (0.1-5ms), moderate ratio (3:1-6:1), and release timed to groove (50-150ms).",
+              "Adjust threshold until you see 3-6dB of gain reduction on each kick hit."
+            ],
+            "body": "The kick drum and bass guitar (or synth bass) both occupy the critical low-frequency range between 40Hz and 80Hz. When both play simultaneously, they compete for the same physical space in speakers and headphones, creating a muddy, undefined low end. This is a fundamental physics problem: a speaker cone can only move in one direction at a time, so overlapping low-frequency signals either reinforce (if perfectly in phase) or cancel each other (if out of phase). More commonly, they simply blur together into indistinct rumble.\n\nSidechain compression solves this by briefly reducing the bass level whenever the kick drum plays, giving the low-end frequency spectrum to the kick during its transient and fundamental tone. As the kick's energy fades, the bass swells back up to fill the space. When done well, the listener doesn't consciously hear ducking—they just hear a tight, punchy low end where kick and bass feel locked together.\n\nHere's the step-by-step setup:\n\n1. Insert Logic's Compressor plugin on your bass track (audio or software instrument).\n\n2. In the compressor interface, locate the 'Side Chain' drop-down menu in the top-right section. Click it and select your kick drum track from the list. If your kick is bussed or part of a drum group, you can select that bus instead.\n\n3. Set the compressor's Attack to 0.1ms to 5ms. You want the compression to engage the instant the kick transient arrives. Fast attack ensures the bass ducks immediately, preventing overlap.\n\n4. Set the Ratio to 3:1 or 4:1 for transparent mixing, or 6:1 to 8:1 if you want more obvious ducking (common in EDM or hip-hop). Higher ratios mean more aggressive volume reduction.\n\n5. Set the Release time based on your track's tempo and groove. For fast dance music (120-128 BPM), try 50ms to 80ms. For slower hip-hop or R&B (80-100 BPM), try 100ms to 150ms. The goal is for the bass to swell back to full volume just as the next kick is about to hit, creating a rhythmic pumping that grooves with the track.\n\n6. Adjust the Threshold until you see the gain-reduction meter showing 3dB to 6dB of reduction on each kick hit. Too much reduction (10dB+) makes the ducking obvious and can kill the bass's energy. Too little (1dB or less) may not solve the masking problem.\n\n7. Leave the Knee at its default (moderate/soft) for most applications. Hard knee creates more obvious compression; soft knee is smoother.\n\n8. Do not add makeup gain on the bass compressor—you're intentionally creating volume reduction here, not trying to make the bass louder overall.\n\n9. Check your mix in mono and at low volume. The kick should feel punchy and defined, and the bass should feel rhythmic and present without fighting the kick.\n\nThis technique is a foundational skill in modern production. It's used on virtually every professional EDM, pop, and hip-hop track. Even rock and metal mixes benefit from subtle kick-bass sidechaining to clean up the low end, though the effect is usually more transparent in those genres.\n\nCommon variations:\n- If your kick has a long tail or sub-bass that extends beyond the transient, adjust the release to match that decay.\n- If the ducking feels too obvious, reduce the ratio or increase the threshold (which reduces how much the compressor engages).\n- For electronic music with perfectly quantized, four-on-the-floor kicks, you can use a volume shaper plugin like LFO Tool or Cableguys ShaperBox instead of a compressor. These let you literally draw the volume curve, avoiding compression artifacts entirely.",
+            "symbolName": "waveform.path",
+            "visualTitle": "Kick-Bass Ducking Setup",
+            "visualCaption": "Bass ducks when kick hits.",
+            "settings": {
+              "Attack": "0.1-5ms (instant response)",
+              "Release": "50-150ms (tempo/groove dependent)",
+              "Ratio": "3:1 to 6:1 (transparent to obvious)",
+              "Gain Reduction Target": "3-6dB per kick hit"
+            },
+            "proTip": "Set your compressor's release time by playing the track and adjusting the knob until the gain-reduction meter 'breathes' with the rhythm—bouncing down and recovering in sync with the groove.",
+            "avoidThis": "Don't set threshold so low that the compressor is always compressing, even when the kick isn't playing. The bass should return to full volume between kicks.",
+            "checkYourWork": "Your kick drum is punchy and clear, the bass has rhythmic movement, and the low end sounds tight in both stereo and mono playback.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step2_kick_bass_compressor.png"
+          },
+          {
+            "number": 43,
+            "title": "Visual Analysis: Kick-Bass Interaction",
+            "concept": "Understanding the waveform and frequency interaction between kick and bass helps you visualize what sidechaining accomplishes.",
+            "actions": [
+              "Use a spectrum analyzer to see frequency overlap between kick and bass.",
+              "Observe the gain-reduction meter on the bass compressor to verify ducking timing.",
+              "Compare the waveform before and after sidechain compression to see the volume reduction."
+            ],
+            "body": "Visual feedback is essential for dialing in effective kick-bass sidechaining. Logic Pro's built-in metering, along with the Channel EQ's analyzer and third-party spectrum analyzers, help you see what's happening in the frequency spectrum.\n\nBefore sidechaining, place Logic's Channel EQ on both the kick and bass tracks (set to Analyzer mode without making EQ changes). Play the section where kick and bass play together. You'll see both tracks' energy concentrated in the 40-80Hz range, with peaks likely overlapping. This overlap is where masking occurs—both sounds are fighting for the same frequency space.\n\nAfter setting up sidechain compression, watch the gain-reduction meter on the bass compressor. You should see the meter respond rhythmically, showing 3-6dB of reduction each time the kick hits, then releasing back to zero before the next kick. If the meter shows constant compression (never fully releasing), your threshold is too low. If it barely moves, your threshold is too high or your ratio is too gentle.\n\nIn the Arrange window, you can visually compare the bass waveform before and after sidechaining by duplicating the bass track, applying sidechain compression to one, and bouncing both to audio for side-by-side comparison. The sidechained version will show distinct 'dips' in amplitude aligned with each kick hit.\n\nSome producers use oscilloscope plugins (like s(M)exoscope or Youlean Loudness Meter's waveform view) to see the actual waveform interaction in real-time. When kick and bass are properly sidechained, you'll see the bass waveform 'duck' or reduce in amplitude precisely when the kick waveform appears.\n\nThis visual approach is especially helpful when learning sidechaining. Once you develop an ear for it, you'll rely more on listening, but visual confirmation speeds up the learning process and helps troubleshoot problems like incorrect release timing or insufficient gain reduction.",
+            "symbolName": "chart.xyaxis.line",
+            "visualTitle": "Frequency Spectrum Analysis",
+            "visualCaption": "See the overlap and the solution.",
+            "settings": {
+              "Key Frequency Range": "40-80Hz (kick/bass fundamental)",
+              "Visual Tools": "Channel EQ analyzer, gain-reduction meter, spectrum analyzer",
+              "Metering Goal": "3-6dB GR on kick hits, full release between"
+            },
+            "proTip": "Use Logic's 'Split by Channel' feature on a stereo analyzer to compare kick and bass frequencies side-by-side, making overlap immediately obvious.",
+            "avoidThis": "Don't rely solely on visual metering—always use your ears to verify that the ducking feels musical and grooves with the track.",
+            "checkYourWork": "You can see the frequency overlap before sidechaining and observe the gain-reduction meter responding rhythmically after sidechaining.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step3_spectrum_analysis.png"
+          },
+          {
+            "number": 44,
+            "title": "Vocal Clarity: Music Bus Sidechaining",
+            "concept": "Routing melodic instruments through a sidechain-compressed bus triggered by vocals creates transparent space for lyrics without obvious ducking.",
+            "actions": [
+              "Create an auxiliary track and route guitars, keys, pads, and backing vocals to it.",
+              "Insert a compressor on the aux track and set its sidechain input to the lead vocal.",
+              "Use gentle settings: 3:1 to 4:1 ratio, 5-10ms attack, 80-150ms release.",
+              "Target 1-3dB of gain reduction during vocal phrases."
+            ],
+            "body": "One of the most powerful but under-discussed applications of sidechaining is creating space for lead vocals by gently compressing the entire musical bed when the vocal is present. This technique is standard in professional pop, rock, and hip-hop mixing, but it's so transparent that most listeners never consciously notice it.\n\nThe problem: when a dense arrangement plays—full band with guitars, keys, pads, synths, backing vocals—the lead vocal can get masked, especially in the 1kHz to 3kHz range where vocal intelligibility lives. You could boost the vocal with EQ or simply turn it up, but this often makes it feel disconnected from the track. Instead, subtly reducing everything else when the vocal is present makes the vocal feel embedded in the mix while remaining clear.\n\nHere's the setup:\n\n1. Create a new auxiliary (bus) track. Name it something like 'Music Bus' or 'Sidechain Aux.'\n\n2. Route all melodic and harmonic tracks to this aux. This typically includes: electric guitars, acoustic guitars, keyboards, synths, pads, strings, backing vocals, and any other mid-range-heavy elements. Do NOT route drums, bass, or lead vocals to this bus—those stay independent.\n\n3. Insert Logic's Compressor on the Music Bus aux track.\n\n4. In the compressor, set the Side Chain input to your lead vocal track.\n\n5. Configure the compressor with these settings:\n   - Ratio: 3:1 to 4:1 (gentle, transparent)\n   - Attack: 5ms to 10ms (fast enough to respond to vocal transients, but not so fast that it creates artifacts)\n   - Release: 80ms to 150ms (should recover between vocal phrases, not during sustained notes)\n   - Knee: Soft (for smooth, gradual compression)\n   - Threshold: adjust until you see 1dB to 3dB of gain reduction when the vocal is singing. During instrumental breaks (no vocal), the compressor should show zero gain reduction.\n\n6. Do not add makeup gain—you want the music to genuinely get quieter when the vocal is present.\n\n7. Solo the vocal and the music bus together, then play a dense section (like a chorus with full instrumentation). You should hear the music subtly 'breathe' around the vocal—ducking slightly when the vocal is loud, swelling back up during rests and between words.\n\nThe beauty of this technique is its transparency. If done correctly, the listener doesn't hear 'pumping' or obvious volume changes—they simply hear a vocal that's clear and present without sounding disconnected. The vocal feels 'in the pocket' of the mix.\n\nThis method is far superior to traditional automation for several reasons:\n- It's automatic: the compressor responds to every vocal phrase without manual rides.\n- It's consistent: every time that vocal phrase plays, the same amount of ducking happens.\n- It's frequency-neutral: unlike EQ, which changes tone, this simply creates dynamic space.\n\nCommon variations:\n- If the ducking is too obvious, reduce the ratio to 2:1 or raise the threshold so less compression happens.\n- If the vocal still isn't cutting through, check if your release time is too fast (causing the music to swell back up too quickly) or if your attack is too slow (letting initial consonants get masked).\n- For more surgical control, use dynamic EQ sidechaining (covered in Step 7) to target only the 1-3kHz vocal range instead of compressing the entire music bus.",
+            "symbolName": "music.note.list",
+            "visualTitle": "Music Bus Method",
+            "visualCaption": "Melodic elements duck for vocal clarity.",
+            "settings": {
+              "Ratio": "3:1 to 4:1",
+              "Attack": "5-10ms",
+              "Release": "80-150ms",
+              "Gain Reduction": "1-3dB during vocal phrases"
+            },
+            "proTip": "If your mix has both a verse and a chorus vocal, use the loudest vocal section (usually the chorus) to set your threshold. The compressor will naturally compress less during quieter verse vocals, creating dynamic variation.",
+            "avoidThis": "Don't route drums or bass to the music bus—sidechaining these creates an unstable, pumping low end. Keep the rhythm section independent.",
+            "checkYourWork": "Your lead vocal is consistently clear and intelligible without sounding louder or disconnected from the track. The music subtly breathes around the vocal.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step4_music_bus_routing.png"
+          },
+          {
+            "number": 45,
+            "title": "Podcast and Voiceover Ducking",
+            "concept": "Sidechaining background music to dialogue tracks ensures spoken words remain intelligible while maintaining atmospheric support.",
+            "actions": [
+              "Place a compressor on your background music or sound effects track.",
+              "Set the sidechain input to your dialogue or voiceover track.",
+              "Use aggressive settings for instant, obvious ducking: 8:1 ratio, <1ms attack, 200-500ms release.",
+              "Target 6-12dB of gain reduction to guarantee dialogue clarity."
+            ],
+            "body": "In podcasts, audiobooks, video production, and film mixing, dialogue clarity is paramount. Listeners need to understand every word without straining, even if background music or ambient sound effects are present. Sidechain compression automates this balance, ensuring music ducks the moment someone speaks and returns when they stop.\n\nUnlike musical sidechaining (which is often subtle), podcast/voiceover ducking is usually obvious and aggressive. The goal is not transparency—it's absolute dialogue priority. Listeners expect background elements to reduce in volume when speech is present, and this ducking is considered standard, professional behavior.\n\nSetup for podcast/voiceover ducking:\n\n1. Arrange your session with dialogue/voiceover on one track and background music/ambience on a separate track (or aux bus if you have multiple background elements).\n\n2. Insert a compressor on the background music track.\n\n3. Set the compressor's sidechain input to the dialogue track.\n\n4. Configure aggressive settings:\n   - Ratio: 8:1 to ∞:1 (limiter-style, for strong ducking)\n   - Attack: 0.1ms to 1ms (instant response to speech)\n   - Release: 200ms to 500ms (should swell back up during natural pauses, not during mid-sentence breaths)\n   - Threshold: adjust until you see 6dB to 12dB of gain reduction whenever dialogue is present. This ensures the background drops significantly, leaving room for speech.\n\n5. Test by playing sections with continuous dialogue. The background music should drop to roughly 25-40% of its normal volume, making dialogue effortlessly clear. During silent sections (no dialogue), the music should return to full volume.\n\n6. Pay special attention to the release time. If it's too fast (under 100ms), the music will pump up and down during natural speech rhythm, sounding unnatural. If it's too slow (over 1 second), the music won't return to full volume during intentional pauses or between speakers, making those pauses feel awkward.\n\nThis technique is so common in podcast production that many podcast-specific tools (like iZotope RX's Dialogue Isolate or dedicated podcast mixing plugins) include preset 'music ducking' modes that essentially automate this exact sidechain compression setup.\n\nFor video production (YouTube, corporate videos, e-learning), this same technique is used to duck background music under narration. Some video editors even automate this in post-production software (Premiere Pro, Final Cut Pro) using built-in audio ducking features, but doing it in Logic Pro during audio post-production gives you more precise control over the compression character.\n\nVariations:\n- For multi-speaker podcasts, route all dialogue tracks to a dialogue bus, then use that bus as the sidechain source. This way, background music ducks when any speaker talks.\n- For audiobooks, you might want less aggressive ducking (4:1 ratio, 3-6dB GR) if the background music is meant to remain present but supportive.\n- For film mixing, you may need to sidechain multiple background layers (music, ambience, effects) separately to the dialogue, giving you granular control over how much each element ducks.",
+            "symbolName": "mic.fill",
+            "visualTitle": "Dialogue Ducking",
+            "visualCaption": "Speech always clear over background.",
+            "settings": {
+              "Ratio": "8:1 to ∞:1",
+              "Attack": "0.1-1ms",
+              "Release": "200-500ms",
+              "Gain Reduction": "6-12dB during dialogue"
+            },
+            "proTip": "Add a high-pass filter to the sidechain input (covered in Step 11) to prevent low-frequency rumble or plosives from triggering the compressor—only mid-range speech frequencies should trigger ducking.",
+            "avoidThis": "Don't use slow attack times (over 10ms) for dialogue ducking—the first syllable of each word may get masked before the compressor engages.",
+            "checkYourWork": "Every word of dialogue is effortlessly clear, and background music feels present during pauses but never competes with speech.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step5_podcast_ducking.png"
+          },
+          {
+            "number": 46,
+            "title": "Reverb Sidechaining for Vocal Clarity",
+            "concept": "Sidechaining vocal reverb to the dry vocal prevents long, washy tails from obscuring lyrics while maintaining a sense of space.",
+            "actions": [
+              "Create a reverb send/return for vocals (aux track with reverb plugin).",
+              "Insert a compressor after the reverb on the aux return.",
+              "Set the compressor's sidechain input to the dry vocal track.",
+              "Use moderate settings: 4:1 ratio, 5-10ms attack, 50-150ms release, targeting 3-6dB GR."
+            ],
+            "body": "Reverb is essential for placing vocals in a believable acoustic space, but long reverb tails can smear lyrics and reduce intelligibility, especially in dense mixes. The traditional solution is to shorten the reverb decay time, but this sacrifices the lush, immersive quality that makes reverb effective. Sidechain compression on the reverb return offers a better solution: let the reverb ring freely during pauses and sustained notes, but duck it when new lyrics arrive.\n\nThis technique is widely used in modern pop, worship music, and ballad production. It allows for dramatic, long-decay reverbs that don't cloud fast lyrical passages.\n\nSetup:\n\n1. Create a standard reverb send/return setup: insert a Send on your lead vocal track, routing it to an auxiliary track. On that aux, insert a reverb plugin (Space Designer, ChromaVerb, or your preferred reverb).\n\n2. After the reverb plugin on the aux return, insert Logic's Compressor.\n\n3. Set the compressor's sidechain input to the dry lead vocal track (not the aux—you want the compressor to 'hear' the original vocal, not the reverb).\n\n4. Configure the compressor:\n   - Ratio: 4:1 to 6:1 (moderate, musical compression)\n   - Attack: 5ms to 10ms (fast enough to respond to new lyrics, slow enough to avoid clicks)\n   - Release: 50ms to 150ms (should release during sustained notes, not instantly)\n   - Threshold: adjust until you see 3dB to 6dB of gain reduction when the vocal is singing. The reverb should duck noticeably, but not disappear.\n\n5. Solo the vocal and reverb aux together. As the vocal sings, the reverb should reduce in level, creating space for the dry vocal. When the vocal sustains a note or pauses, the reverb should swell back up, filling the space with ambience.\n\n6. The result: you can use a 2.5-second reverb decay (which would normally blur fast lyrics) because it's being ducked when the vocal is active and only fully audible during gaps.\n\nThis technique transforms how you approach reverb in dense mixes. You're no longer limited to short, safe decay times—you can use long, lush reverbs that automatically get out of the way when needed.\n\nVariations:\n- For even more surgical control, use a dynamic EQ (like FabFilter Pro-Q 3 or Waves F6) on the reverb return, sidechained to the vocal, targeting only the 1-3kHz midrange. This ducks the 'body' of the reverb without affecting the highs or lows, preserving shimmer and depth.\n- For duet vocals, route both vocalists to the same reverb aux, then sidechain that reverb to a bus containing both vocal tracks. The reverb will duck when either singer is active.\n- If the ducking sounds too obvious, reduce the ratio to 3:1 or increase the release time so the reverb recovers more gently.",
+            "symbolName": "sparkles",
+            "visualTitle": "Reverb Sidechaining",
+            "visualCaption": "Lush reverb that doesn't smear lyrics.",
+            "settings": {
+              "Ratio": "4:1 to 6:1",
+              "Attack": "5-10ms",
+              "Release": "50-150ms",
+              "Gain Reduction": "3-6dB when vocal is active"
+            },
+            "proTip": "Use a longer release time (150ms+) for ballads and slow songs where you want the reverb to feel 'always there.' Use shorter release (50ms) for fast, rhythmic vocal passages.",
+            "avoidThis": "Don't apply this technique to every reverb in your mix—only reverbs on lead elements where clarity matters. Background vocal reverbs, for example, can usually stay untouched.",
+            "checkYourWork": "Your vocal reverb feels spacious and dramatic, but lyrics remain clear even during fast, dense passages. The reverb is most noticeable during pauses and sustained notes.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step6_reverb_sidechain.png"
+          },
+          {
+            "number": 47,
+            "title": "Delay Sidechaining for Clean Repeats",
+            "concept": "Sidechaining delay returns to the dry source prevents delay repeats from cluttering the mix during continuous performance.",
+            "actions": [
+              "Set up a delay send/return on an aux track.",
+              "Insert a compressor after the delay plugin on the aux.",
+              "Sidechain the compressor to the dry source track.",
+              "Use settings similar to reverb sidechaining: 4:1, 5ms attack, 50-150ms release."
+            ],
+            "body": "Delay effects add depth, space, and interest, but long delay tails or multiple repeats can clutter a mix, especially when the source instrument or vocal is playing continuously. Sidechaining the delay return creates a clean, professional sound where delay is audible during gaps but doesn't compete with the dry signal.\n\nThis technique is particularly useful for:\n- Vocal delays where you want distinct echoes at the end of phrases but not during active singing.\n- Guitar delays in dense rock or pop mixes.\n- Dub-style delay throws where the effect is dramatic but shouldn't mask the original performance.\n\nSetup (identical structure to reverb sidechaining):\n\n1. Create a delay send/return: insert a Send on your source track (vocal, guitar, etc.), routing to an auxiliary track. On the aux, insert a delay plugin (Delay Designer, Stereo Delay, Tape Delay, or Echo).\n\n2. After the delay plugin on the aux, insert Logic's Compressor.\n\n3. Set the compressor's sidechain input to the dry source track.\n\n4. Configure the compressor:\n   - Ratio: 4:1 to 6:1\n   - Attack: 5ms to 10ms\n   - Release: 50ms to 150ms (adjust based on delay time—longer delay times may benefit from longer release)\n   - Threshold: adjust until you see 3-6dB of gain reduction when the source is playing. The delay should duck but remain subtly audible.\n\n5. Test with a phrase that has distinct gaps. The delay repeats should be clearly audible during pauses but should sit behind the dry signal when the source is active.\n\n6. For dramatic delay throws (common in EDM, dub, and reggae), increase the ratio to 8:1 or higher so the delay almost disappears when the source plays, then swells up dramatically during gaps.\n\nThis technique is especially powerful for quarter-note or eighth-note delay settings where repeats would otherwise stack up and create rhythmic clutter. With sidechaining, you get the rhythmic interest of timed delays without the mud.\n\nVariations:\n- For ping-pong or stereo delays, apply the sidechain compression after the delay plugin but before any stereo imaging. This keeps the delay's spatial character intact while still ducking its overall level.\n- For feedback-heavy delays (where repeats go on for many cycles), sidechaining prevents the buildup from becoming overpowering.\n- For delay throws on specific words or phrases, consider automating the delay send level instead of relying on sidechaining—this gives you more surgical control over which words get delayed.",
+            "symbolName": "arrow.forward.circle",
+            "visualTitle": "Delay Sidechain Setup",
+            "visualCaption": "Clean repeats during gaps, subtle during performance.",
+            "settings": {
+              "Ratio": "4:1 to 6:1 (or 8:1+ for dramatic ducking)",
+              "Attack": "5-10ms",
+              "Release": "50-150ms",
+              "Gain Reduction": "3-6dB when source is active"
+            },
+            "proTip": "Match the compressor's release time to your delay time for musical interaction. For a quarter-note delay at 120 BPM (500ms delay), try a 200-300ms release so the delay swells back up just before the next repeat.",
+            "avoidThis": "Don't sidechain delay on every track—use it selectively where the delay would otherwise clutter the mix. Simple, short delays often don't need sidechaining.",
+            "checkYourWork": "Delay repeats are distinct and clear during pauses, but don't compete with or muddy the dry source when it's playing.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step7_delay_sidechain.png"
+          },
+          {
+            "number": 48,
+            "title": "Creative Pumping: EDM and Electronic Music",
+            "concept": "Aggressive sidechain compression with exaggerated settings creates the signature 'pumping' effect in electronic dance music.",
+            "actions": [
+              "Sidechain melodic elements (synths, pads, bass, leads) to the kick drum.",
+              "Use extreme settings: 8:1 to ∞:1 ratio, 0.1ms attack, tempo-synced release.",
+              "Target heavy gain reduction: 6-12dB or more for obvious pumping.",
+              "Experiment with release curves and timing for rhythmic character."
+            ],
+            "body": "In electronic dance music—especially house, techno, trance, and future bass—sidechain compression isn't just a mixing tool; it's a core production element. The exaggerated 'pumping' or 'breathing' effect where the entire mix rhythmically ducks around the kick drum is a deliberate aesthetic choice that creates energy, movement, and dancefloor impact.\n\nThis technique became famous in French house (Daft Punk, Justice) and is now ubiquitous in mainstream EDM. The pumping is obvious and intentional—listeners expect it and associate it with the genre.\n\nSetup for creative pumping:\n\n1. Identify which elements should pump. Typically: bass, synth pads, lead synths, plucks, and melodic elements. Drums (other than kick), vocals, and high-end percussion often stay independent for clarity.\n\n2. You can either:\n   - Place a sidechain compressor on each individual track (more control, more CPU).\n   - Route all pumping elements to a single aux bus and compress that bus (easier, more cohesive pumping).\n\n3. For individual tracks or the pumping bus, insert a compressor and set the sidechain input to your kick drum.\n\n4. Configure aggressive settings:\n   - Ratio: 8:1 to ∞:1 (limiter-style compression for maximum pumping)\n   - Attack: 0.1ms to 1ms (instant response to kick transient)\n   - Release: Tempo-synced to your track's BPM. For four-on-the-floor kicks, try setting release so the compressor fully recovers just before the next kick hit. Many compressors offer a 'Note' or 'Sync' release mode—set it to 1/4 note or 1/8 note depending on your kick pattern.\n   - Threshold: adjust until you see 10-15dB of gain reduction on each kick. You want obvious, heavy pumping.\n\n5. Listen to the groove. The pumping should feel rhythmic and musical, not arbitrary. If the release is too fast, the pump will feel abrupt and disconnected. If it's too slow, the elements won't recover before the next kick, creating a constant squashed feeling.\n\n6. The result: every time the kick hits, the entire musical bed ducks dramatically, then swells back up, creating a rhythmic 'breathing' that drives the energy of the track.\n\nMany producers use dedicated sidechain tools instead of traditional compressors for this application:\n- **Volume Shapers** (like Cableguys VolumeShaper or LFO Tool): These let you literally draw the volume envelope, giving you total control over the pump curve. You can create sharp, aggressive ducks or smooth, gentle swells.\n- **Nicky Romero Kickstart**: A plugin designed specifically for EDM-style pumping, with presets and tempo-sync features.\n- **Xfer Records LFO Tool**: Industry-standard for precise control over pumping curves.\n\nThese tools avoid compression artifacts (distortion, tone shift) because they're simply controlling volume, not actually compressing the signal. This can result in cleaner, more controlled pumping.\n\nCreative variations:\n- Pump only specific frequency ranges using multiband sidechain (covered in Step 9). For example, pump the mids and lows but leave the high-end shimmer untouched.\n- Use different release times on different elements: pump pads slowly and heavily, but pump bass quickly for a tighter feel.\n- Automate the sidechain intensity: heavy pumping during buildups and drops, lighter pumping during verses.",
+            "symbolName": "waveform.and.magnifyingglass",
+            "visualTitle": "EDM Pumping Effect",
+            "visualCaption": "Obvious, rhythmic ducking for energy.",
+            "settings": {
+              "Ratio": "8:1 to ∞:1",
+              "Attack": "0.1-1ms",
+              "Release": "Tempo-synced (1/4 or 1/8 note)",
+              "Gain Reduction": "10-15dB or more"
+            },
+            "proTip": "For the cleanest, most controlled pumping, use a volume shaper plugin instead of a compressor—you'll avoid compression artifacts and get precise control over the envelope shape.",
+            "avoidThis": "Don't pump everything including drums (other than kick) and vocals—keep some elements stable so the mix doesn't feel chaotic and unstable.",
+            "checkYourWork": "The pumping is obvious, rhythmic, and musical. It drives the energy of the track and feels locked to the groove, not arbitrary or random.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step8_edm_pumping.png"
+          },
+          {
+            "number": 49,
+            "title": "Dynamic EQ Sidechaining: Surgical Frequency Control",
+            "concept": "Sidechain-triggered dynamic EQ ducks only specific frequency ranges instead of entire tracks, creating transparent space without obvious volume changes.",
+            "actions": [
+              "Use a dynamic EQ plugin (FabFilter Pro-Q 3, Waves F6, or Logic's built-in multiband compressor as a workaround).",
+              "Set the sidechain input to the triggering track (e.g., vocal).",
+              "Target the frequency range where masking occurs (e.g., 1-3kHz for vocal clarity).",
+              "Apply moderate reduction: 2-4dB in the targeted frequency range."
+            ],
+            "body": "Traditional sidechain compression reduces the overall volume of a track, which can feel heavy-handed and obvious. Dynamic EQ sidechaining is a more surgical approach: it only reduces specific frequency ranges where masking occurs, leaving the rest of the track untouched. This creates transparent space without the 'pumping' artifacts of full-range sidechain compression.\n\nFor example, if your lead vocal is being masked by guitars in the 2-3kHz range, you don't need to compress the entire guitar track—you only need to reduce that specific frequency band when the vocal is present. The guitars' low end, high-end sparkle, and overall punch remain intact. This is the approach modern mix engineers use for professional pop and rock productions.\n\nSetup using FabFilter Pro-Q 3 (the industry-standard dynamic EQ with sidechain):\n\n1. Insert Pro-Q 3 on the track that needs frequency space reduction (e.g., rhythm guitars, pads, or a music bus).\n\n2. Enable a dynamic EQ band by clicking a band point and setting its type to 'Dynamic' (the lightning bolt icon).\n\n3. Set the band's frequency to the range where masking occurs. For vocal clarity, try 1.5-3kHz. For kick-bass separation, try 60-100Hz.\n\n4. Set the band's Q (width) to moderate—not too narrow (which sounds surgical and obvious) but not too wide (which affects too much frequency range). Start with Q around 2-4.\n\n5. In Pro-Q 3's sidechain section (bottom of the interface), set the external sidechain input to your triggering track (e.g., lead vocal).\n\n6. Adjust the dynamic band's threshold and range. Threshold determines how loud the trigger signal must be before reduction happens. Range determines how much reduction is applied (typically 2-4dB for transparency, up to 6-8dB for more obvious ducking).\n\n7. The result: when the vocal sings, the guitars' 2-3kHz range ducks by 3dB, creating space for vocal intelligibility. But the guitars' low-end body and high-end sparkle remain unchanged. The listener hears clear vocals without noticing any compression or pumping.\n\nFor Logic Pro users without third-party dynamic EQ:\n- Use Logic's Multipressor as a workaround: split the frequency spectrum into bands, then use external sidechain on the band(s) you want to duck. This is less elegant than Pro-Q 3 but effective.\n- Alternatively, use Trackspacer (a dedicated sidechain dynamic EQ plugin) which automatically analyzes the trigger signal and carves out space in the target track.\n- Or use standard sidechain compression with a sidechain EQ filter (covered in Step 11) to make the compressor only 'hear' specific frequencies. This is less precise than true dynamic EQ but can work for simple cases.\n\nDynamic EQ sidechaining is particularly useful for:\n- Vocal clarity in dense pop/rock mixes.\n- Podcast/voiceover where you want to duck music's midrange without affecting bass and treble.\n- Kick-bass separation where you want to duck the bass's 60-80Hz fundamental without affecting its upper harmonics.\n- Reducing sibilance clashes between lead and backing vocals (duck the backing vocals' 6-8kHz range when the lead vocal is present).",
+            "symbolName": "waveform.path.ecg",
+            "visualTitle": "Dynamic EQ Sidechain",
+            "visualCaption": "Target frequencies, not entire tracks.",
+            "settings": {
+              "Common Ranges": "Vocals: 1.5-3kHz, Kick-Bass: 60-100Hz, Sibilance: 6-8kHz",
+              "Reduction Amount": "2-4dB for transparency, 6-8dB for obvious space",
+              "Q (Width)": "2-4 (moderate, musical)",
+              "Tools": "FabFilter Pro-Q 3, Waves F6, Trackspacer, iZotope Neutron"
+            },
+            "proTip": "Use Pro-Q 3's real-time analyzer to visually identify exactly which frequency range is causing masking, then place your dynamic EQ band right on that peak.",
+            "avoidThis": "Don't use overly narrow Q values (10+) which create surgical, obvious dips. Dynamic EQ should be felt, not heard.",
+            "checkYourWork": "Your lead element (vocal, kick, etc.) is clear and present, but the overall tonal balance of supporting tracks remains unchanged. The space creation is transparent.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step9_dynamic_eq.png"
+          },
+          {
+            "number": 50,
+            "title": "Multiband Sidechain Compression",
+            "concept": "Splitting audio into frequency bands and sidechaining only specific bands preserves tonal balance while creating targeted dynamic space.",
+            "actions": [
+              "Use Logic's Multipressor or a third-party multiband compressor.",
+              "Split the frequency spectrum (e.g., Low: <200Hz, Mid: 200-5kHz, High: >5kHz).",
+              "Enable external sidechain on the band(s) you want to duck (typically Low or Mid).",
+              "Leave other bands untouched or use gentle settings."
+            ],
+            "body": "Multiband sidechain compression combines the best aspects of full-range sidechain and dynamic EQ: it splits audio into multiple frequency bands, then applies sidechain compression only to the bands where you need it. This is more flexible than standard sidechain (which affects everything) and easier to set up than dynamic EQ (which requires precision frequency selection).\n\nCommon applications:\n\n**Low-End Ducking:** Sidechain only the low band (<150Hz) of a bass track to the kick, leaving the bass's midrange and harmonic content untouched. This creates kick-bass separation without losing the 'warmth' and 'body' of the bass tone.\n\n**Vocal Clarity:** Sidechain only the midrange band (1-4kHz) of a music bus to the vocal, leaving lows and highs intact. This creates vocal space without affecting the bass or high-frequency shimmer.\n\n**Podcast/VO Ducking:** Sidechain the midrange band of background music to dialogue, leaving the music's bass and treble at full volume. This maintains musical richness while ensuring speech clarity.\n\nSetup in Logic Pro using Multipressor:\n\n1. Insert Logic's Multipressor on the target track (the one that should be affected).\n\n2. Set up your crossover points to split the frequency spectrum. For kick-bass example: Low band up to 150Hz, Mid band 150Hz to 5kHz, High band above 5kHz.\n\n3. For each band you want to sidechain, click the band's settings and enable the external sidechain input. Set it to your trigger track (e.g., kick drum).\n\n4. Configure the compression settings for each sidechained band:\n   - Low band (for kick-bass): Ratio 4:1-6:1, fast attack (0.1ms), moderate release (80-150ms), threshold for 3-6dB GR.\n   - Mid band (for vocal clarity): Ratio 3:1-4:1, 5-10ms attack, 100-200ms release, threshold for 2-4dB GR.\n\n5. Leave bands you don't want to duck either bypassed or set to very gentle settings.\n\n6. The result: you get targeted frequency-specific ducking without affecting the entire tonal balance of the track.\n\nThird-party multiband compressors with better sidechain features:\n- **FabFilter Pro-MB**: Offers up to 6 bands with individual sidechain inputs, per-band attack/release, and excellent visual feedback.\n- **Waves C6**: Industry-standard multiband with sidechain on each band.\n- **iZotope Ozone Dynamics**: Multiband mode with sidechain, often used for mastering-style multiband ducking.\n\nMultiband sidechaining is especially powerful when:\n- You want the benefits of dynamic EQ sidechaining but don't want to invest in FabFilter Pro-Q 3.\n- You need different ducking behavior in different frequency ranges (e.g., aggressive ducking in the lows, gentle ducking in the mids, no ducking in the highs).\n- You're working with complex, full-bandwidth sources (like synth pads or guitar buses) where simple full-range compression would be too heavy-handed.",
+            "symbolName": "square.split.diagonal",
+            "visualTitle": "Multiband Sidechain",
+            "visualCaption": "Frequency-specific ducking with tonal preservation.",
+            "settings": {
+              "Low Band": "<150Hz (kick-bass separation)",
+              "Mid Band": "150Hz-5kHz (vocal clarity)",
+              "High Band": ">5kHz (usually left alone)",
+              "Tools": "Logic Multipressor, FabFilter Pro-MB, Waves C6"
+            },
+            "proTip": "Use multiband sidechain on synth pads and atmospheric elements—duck only the mids for vocal space while leaving the lush low-end sub and high-end shimmer untouched.",
+            "avoidThis": "Don't sidechain all bands equally—that's just standard sidechain with extra CPU load. Use multiband specifically to target problem frequency ranges.",
+            "checkYourWork": "You've created space in the critical frequency range (e.g., low end for kick, mids for vocal) without altering the overall tonal character of the track.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step10_multiband_sidechain.png"
+          },
+          {
+            "number": 51,
+            "title": "Sidechain EQ Filtering for Targeted Triggering",
+            "concept": "Using the sidechain input's built-in EQ filter makes the compressor respond only to specific frequencies, creating more musical and transparent results.",
+            "actions": [
+              "In your sidechain compressor, locate the 'Filter' or 'Side Chain EQ' section.",
+              "Enable filtering and choose a filter type (high-pass, low-pass, or bandpass).",
+              "Set the filter frequency to isolate the trigger signal's most relevant range.",
+              "Test and adjust—the compressor should now respond only to filtered frequencies."
+            ],
+            "body": "By default, when you set up sidechain compression, the compressor 'listens' to the full frequency spectrum of the trigger track. But often, only certain frequencies are relevant. For kick-bass ducking, you only care about the kick's low-frequency thump (40-100Hz), not its high-frequency click. For vocal sidechaining, you only care about the vocal's intelligibility range (1-4kHz), not its breath noise or sibilance.\n\nLogic Pro's Compressor includes a built-in 'Side Chain' filter section that lets you EQ the sidechain input, making the compressor respond only to the frequencies you choose. This creates more musical, transparent compression with fewer artifacts.\n\nCommon filter applications:\n\n**High-Pass Filter (HPF):** Makes the compressor ignore low frequencies. Use this when sidechaining to vocals or dialogue to prevent plosives, breath noise, and low-frequency rumble from triggering compression. Set the HPF to 80-150Hz so the compressor only 'hears' the actual speech/vocal tone.\n\n**Low-Pass Filter (LPF):** Makes the compressor ignore high frequencies. Use this when sidechaining bass to kick—set an LPF around 120-200Hz so the compressor only responds to the kick's fundamental thump, not its beater click or cymbal bleed.\n\n**Bandpass Filter (BPF):** Makes the compressor only 'hear' a specific frequency range. Use this for surgical applications: for example, set a bandpass around 2-3kHz when sidechaining a music bus to vocals, so the compressor only responds to the core vocal intelligibility range.\n\n**Parametric EQ:** Some compressors (including Logic's) offer a parametric bell filter in the sidechain. Use this to emphasize a specific frequency that should trigger compression more strongly. For example, boost 60Hz in the sidechain when compressing bass to kick, making the compressor extra-sensitive to the kick's fundamental.\n\nSetup in Logic Pro's Compressor:\n\n1. Set up your sidechain compression as usual (compressor on target track, sidechain input set to trigger track).\n\n2. In the Compressor interface, locate the 'Side Chain' section (usually collapsed—click the disclosure triangle to expand it).\n\n3. Enable the 'Filter' checkbox.\n\n4. Choose your filter type from the drop-down: LP (low-pass), BP (bandpass), HP (high-pass), ParEQ (parametric), or HS (high shelf).\n\n5. Adjust the filter frequency and Q (width) to target your desired range. For example:\n   - Kick-bass with LPF: Set frequency to 150Hz so only low-end triggers compression.\n   - Vocal clarity with BPF: Set center frequency to 2.5kHz, Q around 1.5, so only vocal presence range triggers compression.\n   - Dialogue ducking with HPF: Set frequency to 100Hz to ignore rumble and plosives.\n\n6. Listen and adjust. The compressor's behavior will change—it should now respond more musically and predictably because it's only 'hearing' the relevant frequencies.\n\nThis technique is incredibly powerful but often overlooked. It can transform overly aggressive sidechain compression into smooth, musical ducking simply by making the compressor ignore irrelevant frequency content.\n\nThird-party compressors often have even more sophisticated sidechain filtering:\n- **FabFilter Pro-C 2:** Includes a built-in sidechain EQ with full parametric controls and real-time spectrum analysis.\n- **Waves Renaissance Compressor:** Offers sidechain high-pass and low-pass filters.\n- **SSL Native Bus Compressor:** Includes the famous SSL sidechain filter controls (SC HPF).",
+            "symbolName": "slider.vertical.3",
+            "visualTitle": "Sidechain Filter Control",
+            "visualCaption": "Make compressor respond only to relevant frequencies.",
+            "settings": {
+              "HPF (vocal/dialogue)": "80-150Hz (ignore rumble)",
+              "LPF (kick-bass)": "120-200Hz (only thump triggers)",
+              "BPF (vocal clarity)": "2-3kHz center (presence range)",
+              "ParEQ": "Boost or cut to emphasize specific triggers"
+            },
+            "proTip": "Use FabFilter Pro-C 2's sidechain audition feature (headphone icon) to solo what the compressor is 'hearing'—this makes dialing in the perfect filter setting instant and obvious.",
+            "avoidThis": "Don't use extremely narrow bandpass filters (Q > 10) unless you have a very specific reason—this can make the compressor respond inconsistently as the trigger track's frequency content varies.",
+            "checkYourWork": "Your sidechain compression responds smoothly and predictably, with fewer false triggers and more musical ducking that follows the most important elements of the trigger signal.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step11_sidechain_filter.png"
+          },
+          {
+            "number": 52,
+            "title": "Gate Sidechaining for Rhythmic Effects",
+            "concept": "Using a sidechain-triggered gate creates rhythmic chopping, stuttering, and on/off effects synchronized to a trigger track.",
+            "actions": [
+              "Insert Logic's Noise Gate on the track you want to rhythmically chop.",
+              "Set the gate's sidechain input to a rhythmic trigger (kick, hi-hat, or dedicated trigger track).",
+              "Use fast attack (0.1ms), adjust threshold for full gating, and set hold/release for desired effect length.",
+              "Create dramatic rhythmic effects synchronized to another element."
+            ],
+            "body": "While most sidechaining discussions focus on compression (which reduces volume), gate sidechaining is equally powerful for creative production. A noise gate silences audio when the trigger signal is below a threshold—when sidechained, this means the target track only plays when the trigger is present. This creates rhythmic chopping, stuttering, and gating effects that are perfectly locked to another element's rhythm.\n\nCommon creative applications:\n\n**Rhythmic Pad Gating:** Sidechain a lush pad or string sound to a kick or hi-hat pattern. The pad will only play when the trigger hits, creating a rhythmic, pulsing texture instead of a sustained drone. This is common in trance, techno, and progressive house.\n\n**Vocal Chopping:** Sidechain a vocal sample to a rhythmic MIDI trigger track (silent, used only for triggering). Create a MIDI pattern with the rhythm you want, then use it to 'slice' the vocal into rhythmic fragments.\n\n**Bass Gating:** Sidechain a sustained bass note to a kick or hi-hat. The bass will play in sync with the drums, creating a staccato, rhythmic bass line from what was originally a long sustained note.\n\n**Reverse Ducking (Creative Effect):** Use a gate sidechained to kick to make a synth or pad *only* play when the kick hits, creating a pumping effect that's the opposite of standard sidechain compression.\n\nSetup:\n\n1. Insert Logic's Noise Gate on the track you want to rhythmically chop (target).\n\n2. Set the gate's 'Side Chain' input to your trigger track (kick, hi-hat, or a dedicated MIDI trigger track).\n\n3. Configure the gate:\n   - Threshold: Set high enough that the target track is fully gated (silent) when the trigger is not present. You'll need to adjust by ear—start around -20dB and increase until you hear complete silence between triggers.\n   - Attack: Set to fastest (0.1ms) for instant gating, or slower (10-50ms) for a fade-in effect on each gate opening.\n   - Hold: Determines how long the gate stays open after the trigger stops. For short, staccato effects, use 10-50ms. For longer, more sustained gates, use 100-300ms.\n   - Release: How quickly the gate closes (fades out) after the hold time. Fast release (10-50ms) creates abrupt cuts. Slower release (100-300ms) creates smooth fade-outs.\n\n4. Test different trigger sources:\n   - Sidechain to kick for four-on-the-floor rhythmic gating.\n   - Sidechain to hi-hats for faster, more intricate rhythmic patterns.\n   - Sidechain to a custom MIDI trigger track for complete rhythmic control.\n\n5. Experiment with attack/hold/release to shape the character of the gating. Short settings create stuttering, glitchy effects. Long settings create smooth, pulsing textures.\n\nAdvanced techniques:\n- Use the gate's 'Hysteresis' control (if available) to prevent flutter when the trigger signal is near the threshold.\n- Combine gate sidechaining with volume automation for hybrid effects: gate for rhythmic structure, automation for musical phrasing.\n- Use a multiband gate (or split your signal into bands and gate each separately) for frequency-specific rhythmic gating—for example, gate only the midrange of a pad while leaving bass and treble sustained.\n\nGate sidechaining is less common in traditional mixing but extremely popular in electronic production, sound design, and remix work. It's a fast way to create complex rhythmic patterns from static, sustained sounds.\n\nThird-party gate plugins with advanced sidechain features:\n- **FabFilter Pro-G:** Industry-standard gate with sidechain input, per-band gating, and visual metering.\n- **Waves Renaissance DeEsser/Gate:** Classic gate with sidechain.\n- **Logic's own Enveloper:** While not technically a gate, it can be sidechained and used for similar rhythmic effects.",
+            "symbolName": "bolt.horizontal.circle",
+            "visualTitle": "Rhythmic Gate Sidechain",
+            "visualCaption": "Chop and slice in sync with triggers.",
+            "settings": {
+              "Attack": "0.1ms (instant) or 10-50ms (fade-in)",
+              "Hold": "10-50ms (staccato) or 100-300ms (sustained)",
+              "Release": "10-50ms (abrupt) or 100-300ms (smooth)",
+              "Threshold": "Adjust for complete gating"
+            },
+            "proTip": "Create a dedicated MIDI trigger track with no sound output—just MIDI notes—then use it to sidechain-gate any audio track. This gives you complete rhythmic control without being tied to existing drum patterns.",
+            "avoidThis": "Don't use gate sidechaining on lead vocals or primary melodic elements in traditional mixes—it's too destructive. Reserve it for creative production and sound design.",
+            "checkYourWork": "Your target track plays only when the trigger is active, creating a tight, rhythmic effect that's perfectly locked to the groove. The gating is clean without clicks or artifacts.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step12_gate_sidechain.png"
+          },
+          {
+            "number": 53,
+            "title": "Creative Auto-Filter Sidechaining",
+            "concept": "Sidechain-triggered auto-filters create dynamic tone changes synchronized to other tracks, useful for rhythmic filtering and movement.",
+            "actions": [
+              "Insert Logic's Auto Filter on the track you want to affect.",
+              "Set the filter type (low-pass, high-pass, or bandpass) and configure cutoff/resonance.",
+              "Enable sidechain input and select your trigger track.",
+              "Adjust envelope controls to shape how the filter responds to the trigger."
+            ],
+            "body": "Beyond compression and gating, Logic Pro's Auto Filter plugin supports sidechain input, allowing filter cutoff to be modulated by external audio sources. This creates dynamic, rhythmic filtering effects where a track's tone changes in response to another element—common in electronic music, dub, and creative sound design.\n\nApplications:\n\n**Rhythmic Low-Pass Filtering:** Sidechain a synth pad's Auto Filter to the kick. The pad's brightness increases when the kick hits, then dulls between kicks, creating rhythmic movement.\n\n**Dub-Style High-Pass Sweeps:** Sidechain a bass or guitar's Auto Filter to a hi-hat or shaker. The filter opens and closes rhythmically, creating classic dub/reggae filtering effects.\n\n**Dynamic Vocal Effects:** Sidechain a doubled vocal or harmony's Auto Filter to the lead vocal. The doubled vocal's tone shifts when the lead sings, creating space and movement.\n\nSetup:\n\n1. Insert Logic's Auto Filter on your target track.\n\n2. Choose a filter type:\n   - Low-Pass (LP): Typical for rhythmic brightness changes.\n   - High-Pass (HP): Useful for creating 'thinning' effects synchronized to triggers.\n   - Band-Pass (BP): For more dramatic, sweeping tonal shifts.\n\n3. Set the cutoff frequency and resonance to taste. Higher resonance creates more pronounced filter 'sweep' character.\n\n4. Enable the Auto Filter's external sidechain input and select your trigger track.\n\n5. Adjust the envelope and dynamics controls:\n   - Attack: How quickly the filter opens when triggered.\n   - Release: How quickly the filter closes after the trigger stops.\n   - Amount: How much the filter cutoff moves (the range of the sweep).\n\n6. The result: when your trigger plays, the filter cutoff moves, changing the target track's tone in sync with the trigger's rhythm.\n\nThis technique is less common in traditional mixing but extremely powerful for:\n- Creating movement and interest in static, sustained sounds (pads, drones).\n- Adding rhythmic complexity without additional instruments.\n- Dub production and remix work where filter sweeps are a core aesthetic element.\n\nAdvanced variations:\n- Combine auto-filter sidechaining with standard sidechain compression for hybrid effects: the track ducks in volume *and* tone simultaneously.\n- Use automation to change the filter's cutoff frequency over time while the sidechain controls the dynamic movement.\n- Route multiple tracks through a bus with a sidechain auto-filter for cohesive, ensemble filtering effects.",
+            "symbolName": "waveform.path.badge.minus",
+            "visualTitle": "Auto-Filter Sidechain",
+            "visualCaption": "Dynamic tone changes synchronized to triggers.",
+            "settings": {
+              "Filter Type": "Low-Pass (brighten/dull), High-Pass (thin/full), Band-Pass (sweeps)",
+              "Cutoff & Resonance": "Set base tone character",
+              "Sidechain Amount": "Controls depth of filter modulation",
+              "Envelope": "Attack/Release shape the filter movement"
+            },
+            "proTip": "Use subtle auto-filter sidechaining on background vocals or doubled instruments to create space for lead elements without obvious volume ducking—the tonal shift is often less noticeable than compression.",
+            "avoidThis": "Don't apply heavy resonance with fast sidechain triggering—this can create harsh, whistling artifacts. Keep resonance moderate for musical results.",
+            "checkYourWork": "Your target track's tone changes rhythmically in sync with the trigger, creating movement and interest without artifacts or harshness.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step13_autofilter_sidechain.png"
+          },
+          {
+            "number": 54,
+            "title": "Troubleshooting Common Sidechaining Problems",
+            "concept": "Understanding common artifacts and issues—pumping, clicks, inconsistent triggering, and over-compression—helps you achieve clean, professional results.",
+            "actions": [
+              "Identify audible artifacts: clicks, pumping, distortion, or loss of energy.",
+              "Check attack/release times: too fast causes clicks, too slow causes sluggish response.",
+              "Verify threshold and ratio: ensure gain reduction is appropriate for the task.",
+              "Use sidechain filtering or dynamic EQ to prevent false triggers."
+            ],
+            "body": "Even with proper setup, sidechain compression can introduce unwanted artifacts or fail to work as intended. Here are the most common problems and their solutions:\n\n**Problem 1: Audible Clicking or Popping**\n- Cause: Attack time is too fast (especially <1ms) or release is too fast with high gain reduction.\n- Solution: Increase attack to 3-10ms for smoother envelope response. Increase release to at least 50ms. Use soft knee for gentler compression onset.\n\n**Problem 2: Obvious, Unmusical Pumping**\n- Cause: Too much gain reduction (10dB+), or release time is out of sync with the track's rhythm.\n- Solution: Reduce ratio (from 8:1 down to 4:1), raise threshold to reduce gain reduction, or adjust release time so the compressor recovers musically (try tempo-synced release). For transparent mixing, aim for 2-6dB GR, not 10dB+.\n\n**Problem 3: Inconsistent or Weak Triggering**\n- Cause: Trigger signal is too quiet, or sidechain filtering is removing the relevant frequencies.\n- Solution: Check that your trigger track (e.g., kick) is actually loud enough to cross the threshold. Disable sidechain filtering temporarily to verify. If the trigger is a drum bus with multiple elements, consider using just the isolated kick for cleaner triggering.\n\n**Problem 4: Compressor Always Compressing (No Recovery)**\n- Cause: Threshold is set too low, or release is too long.\n- Solution: Raise the threshold so the compressor only engages when the trigger actually plays. Shorten release time so the compressor recovers between triggers. Check the gain-reduction meter—it should return to zero between triggers.\n\n**Problem 5: Loss of Energy or 'Dead' Sound**\n- Cause: Too much compression, or you've sidechained too many elements simultaneously.\n- Solution: Reduce the number of sidechained tracks—keep some elements stable for mix energy. Use multiband or dynamic EQ sidechaining instead of full-range compression to preserve tonal balance. Check makeup gain—though typically not needed for sidechaining, extremely heavy compression may benefit from a small amount to restore perceived loudness.\n\n**Problem 6: Distortion or Harsh Artifacts**\n- Cause: Over-compression with high ratio and low threshold, or compressor topology mismatch (some compressors add color/saturation that clashes with the source).\n- Solution: Switch compressor types—use a clean VCA or digital compressor instead of a colored Opto or FET model. Reduce ratio and increase threshold. Use multiband sidechaining to avoid compressing already-distorted frequency ranges.\n\n**Problem 7: Sidechain Not Working At All**\n- Cause: Sidechain routing is incorrect, or plugin doesn't support external sidechain.\n- Solution: Verify the sidechain input is actually set to your trigger track (check the 'Side Chain' menu in the compressor). Ensure the trigger track contains audio and isn't muted or soloed in a way that bypasses the sidechain send. Verify the compressor plugin supports external sidechain (Logic's stock Compressor does; some third-party plugins may not).\n\n**Problem 8: Phase Cancellation or Hollow Sound**\n- Cause: When using parallel or bus-based sidechaining, the sidechained element and non-sidechained elements may be out of phase, especially in the low end.\n- Solution: Use Logic's Gain Utility plugin to flip phase on one of the elements. Check correlation metering. Avoid heavy sidechain compression on low-end elements if phase issues persist—use dynamic EQ or multiband instead.\n\nGeneral troubleshooting workflow:\n1. Bypass the sidechain compressor and compare. If the 'improved' version sounds worse, reduce the intensity or rethink the approach.\n2. Solo the affected track and listen for artifacts (clicks, pumping, distortion) without the rest of the mix.\n3. Check the gain-reduction meter—it should respond rhythmically and predictably. If it's erratic or constantly pinned, your settings need adjustment.\n4. Test in mono. Sidechaining issues (especially phase problems) often become more obvious in mono playback.\n5. Take a break. Ear fatigue makes artifacts harder to identify. Fresh ears catch problems quickly.",
+            "symbolName": "wrench.and.screwdriver",
+            "visualTitle": "Troubleshooting Guide",
+            "visualCaption": "Identify and fix common artifacts.",
+            "settings": {
+              "Clicks": "Increase attack/release, use soft knee",
+              "Pumping": "Reduce ratio, raise threshold, adjust release timing",
+              "Weak Triggering": "Check trigger level, disable sidechain filter",
+              "Always Compressing": "Raise threshold, shorten release",
+              "Distortion": "Lower ratio, switch compressor type"
+            },
+            "proTip": "Create a 'test session' with a simple kick and bass to dial in your preferred sidechain settings. Save these as compressor presets you can recall in future projects.",
+            "avoidThis": "Don't keep adding more compression or stacking multiple sidechain compressors to 'fix' problems—often the solution is less compression, better settings, or a different approach (like dynamic EQ).",
+            "checkYourWork": "Your sidechain compression is transparent and musical (for mixing) or intentionally obvious (for creative effects), with no audible clicks, distortion, or unnatural pumping.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step14_troubleshooting.png"
+          },
+          {
+            "number": 55,
+            "title": "Advanced Workflow: Bus-Based Sidechaining",
+            "concept": "Routing multiple tracks to buses for cohesive sidechain behavior reduces CPU load and creates unified ducking across track groups.",
+            "actions": [
+              "Group related tracks (synths, guitars, pads) onto a bus.",
+              "Apply sidechain compression to the bus instead of individual tracks.",
+              "Use separate buses for different instrument families with unique sidechain needs.",
+              "Reduce CPU load while maintaining consistent, musical ducking."
+            ],
+            "body": "When mixing complex sessions with many tracks, applying individual sidechain compressors to each track is inefficient and can create inconsistent ducking where different elements pump at different rates. Bus-based sidechaining solves this by grouping related tracks onto auxiliary buses and applying a single sidechain compressor to each bus. This creates cohesive, unified ducking and significantly reduces CPU load.\n\nCommon bus groupings for sidechaining:\n\n**Melodic Bus:** Route all synths, keys, pads, and melodic instruments to one aux. Sidechain this bus to the lead vocal for transparent vocal clarity across all melodic content.\n\n**Rhythm Bus (non-kick/bass):** Route percussion, hi-hats, shakers, and rhythm elements to one aux. Sidechain to kick for EDM-style pumping that affects rhythmic layers but not the bass.\n\n**Background Vocal Bus:** Route all backing vocals and harmonies to one aux. Sidechain to lead vocal for automatic space creation without affecting individual backing vocal levels.\n\n**Pad Bus:** Route all atmospheric pads, strings, and ambient textures to one aux. Sidechain to drums or vocal for breathing space in dense sections.\n\nSetup workflow:\n\n1. Identify which tracks have similar sidechaining needs (same trigger source, similar compression settings).\n\n2. Create an auxiliary track for the group. Name it descriptively (e.g., 'Melodic Bus - SC').\n\n3. Route all relevant tracks to this aux by setting their output to the aux bus.\n\n4. Insert a compressor on the aux track and configure sidechain input and settings as usual.\n\n5. The entire group now ducks together, creating cohesive movement. If one synth needs different ducking, split it to a separate bus with unique settings.\n\nBenefits:\n- **CPU Efficiency:** One compressor instance instead of five or ten.\n- **Cohesion:** All elements in the bus duck together, creating unified movement rather than individual pumping.\n- **Mix Glue:** Bus-based sidechaining naturally groups elements sonically, helping them feel like they belong together.\n- **Easier Automation:** You can automate the bus's sidechain intensity (via threshold or ratio) to create dynamic changes (e.g., heavy pumping in the chorus, light pumping in the verse) without touching individual tracks.\n\nAdvanced variations:\n- Use **multiple buses** with different sidechain settings: a 'Heavy SC Bus' for tracks that should pump obviously, and a 'Light SC Bus' for tracks that need subtle ducking.\n- **Parallel sidechain processing:** Route tracks to both a sidechained bus and a non-sidechained bus, then blend them for hybrid ducking intensity.\n- **Nested buses:** Create a master 'Music Bus' with moderate sidechaining, then create sub-buses (guitars, keys, pads) with individual sidechain settings. This gives you both broad and surgical control.\n\nThis approach is standard in professional pop, EDM, and film mixing. It's how engineers manage complex sessions with dozens of tracks while maintaining CPU efficiency and mix cohesion.",
+            "symbolName": "point.3.filled.connected.trianglepath.dotted",
+            "visualTitle": "Bus-Based Sidechaining",
+            "visualCaption": "Group tracks for cohesive ducking.",
+            "settings": {
+              "Melodic Bus": "All synths/keys/melodic → sidechain to vocal",
+              "Rhythm Bus": "All perc (non-kick) → sidechain to kick",
+              "Pad Bus": "All pads/strings → sidechain to drums/vocal",
+              "BG Vocal Bus": "All backing vocals → sidechain to lead vocal"
+            },
+            "proTip": "Create color-coded track labels for sidechained buses so you can quickly identify which elements are being affected at a glance in large sessions.",
+            "avoidThis": "Don't route your entire mix (including drums and bass) to a single sidechained bus—this creates unstable, pumping mixes. Only route elements that genuinely need ducking.",
+            "checkYourWork": "Related tracks duck together as a cohesive group, creating unified movement. CPU load is reduced compared to individual track-by-track sidechaining.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step15_bus_routing.png"
+          },
+          {
+            "number": 56,
+            "title": "Sidechaining in Different Genres",
+            "concept": "Different musical genres have distinct sidechaining conventions—understanding genre expectations helps you apply appropriate techniques.",
+            "actions": [
+              "Identify genre-specific sidechaining norms (transparent for pop/rock, obvious for EDM, functional for podcasts).",
+              "Adjust intensity based on genre: subtle for acoustic/jazz, moderate for pop/hip-hop, extreme for EDM.",
+              "Study reference tracks in your genre to understand sidechaining conventions.",
+              "Balance technical needs (clarity) with creative expectations (pumping)."
+            ],
+            "body": "Sidechaining is not one-size-fits-all. Each genre has different conventions, expectations, and intensity levels. Understanding these norms helps you apply sidechaining appropriately and avoid genre-inappropriate choices.\n\n**Pop Music:**\n- **Approach:** Transparent to moderate. Sidechaining is used for vocal clarity (music bus method) and subtle low-end management (kick-bass ducking).\n- **Settings:** 2:1 to 4:1 ratio, 2-6dB gain reduction, moderate attack/release.\n- **Goal:** Vocals clear and upfront, low end tight, but no obvious pumping. Listeners shouldn't consciously notice the ducking.\n- **Reference:** Taylor Swift, The Weeknd, Ariana Grande—vocals are effortlessly clear without sounding disconnected.\n\n**EDM / Electronic Dance Music (House, Trance, Techno, Future Bass):**\n- **Approach:** Obvious and aggressive. Sidechaining is a production element, not just a mix tool. Heavy pumping creates energy and movement.\n- **Settings:** 8:1 to ∞:1 ratio, 10-15dB+ gain reduction, fast attack (0.1ms), tempo-synced release.\n- **Goal:** Dramatic, rhythmic pumping that grooves with the kick. The effect is intentional and central to the genre's sound.\n- **Reference:** Daft Punk ('One More Time'), Deadmau5, Calvin Harris—obvious pumping on pads, synths, and bass.\n\n**Hip-Hop / Trap:**\n- **Approach:** Moderate kick-bass sidechaining for low-end clarity. Minimal or no sidechaining on melodic elements unless the beat is heavily electronic.\n- **Settings:** 3:1 to 6:1 ratio, 3-6dB gain reduction on bass, fast attack, moderate release.\n- **Goal:** Kick hits hard and clear without fighting the 808 bass. Upper mix stays stable.\n- **Reference:** Metro Boomin, Travis Scott, Drake—tight low end, but no obvious pumping in the melodic content.\n\n**Rock / Indie:**\n- **Approach:** Subtle or none. Rock mixes traditionally use EQ, panning, and arrangement for separation. Sidechaining is less common and should be transparent if used.\n- **Settings:** If used, 2:1 to 3:1 ratio, 1-3dB gain reduction, gentle settings.\n- **Goal:** Maintain natural dynamics and energy. Sidechaining should solve specific masking issues without altering the genre's organic feel.\n- **Reference:** Foo Fighters, Arctic Monkeys—separation through EQ and arrangement, not obvious ducking.\n\n**Podcast / Voiceover / Film:**\n- **Approach:** Functional and aggressive. Dialogue is always priority one. Background music and ambience must duck clearly when speech is present.\n- **Settings:** 8:1 to ∞:1 ratio, 6-12dB gain reduction, instant attack, moderate release (200-500ms).\n- **Goal:** 100% dialogue intelligibility without listener effort. Ducking is expected and accepted.\n- **Reference:** Professional podcasts (The Daily, Radiolab), film dialogue—music always yields to speech.\n\n**Acoustic / Jazz / Classical:**\n- **Approach:** Minimal or none. These genres prioritize natural dynamics, live performance feel, and organic separation. Sidechaining is rare and should be nearly inaudible if used.\n- **Settings:** If absolutely needed, 1.5:1 to 2:1 ratio, 1-2dB gain reduction, very gentle.\n- **Goal:** Preserve natural performance dynamics. Use traditional mixing techniques (EQ, level balance) instead of heavy processing.\n- **Reference:** Most acoustic and jazz recordings avoid sidechaining entirely.\n\n**Dub / Reggae:**\n- **Approach:** Creative and rhythmic. Sidechaining (especially gate sidechaining and auto-filter sidechaining) is used for dub effects, rhythmic filtering, and space creation.\n- **Settings:** Varies widely—can be subtle or extreme depending on the effect. Often uses gating and filtering instead of compression.\n- **Goal:** Create rhythmic, pulsing textures that are part of the genre's aesthetic.\n- **Reference:** King Tubby, Lee 'Scratch' Perry—heavy use of rhythmic gating and filtering.\n\nKey takeaway: Always reference professional tracks in your genre before applying sidechaining. What's essential in EDM would be inappropriate in jazz. What's subtle in pop would be invisible in house music. Matching genre expectations is as important as technical execution.",
+            "symbolName": "music.quarternote.3",
+            "visualTitle": "Genre-Specific Sidechaining",
+            "visualCaption": "Different genres, different intensity.",
+            "settings": {
+              "Pop": "Transparent, 2-6dB GR, vocal clarity focus",
+              "EDM": "Obvious, 10-15dB+ GR, rhythmic pumping",
+              "Hip-Hop": "Moderate, 3-6dB GR, kick-bass only",
+              "Rock": "Minimal, 1-3dB GR or none, natural dynamics",
+              "Podcast": "Aggressive, 6-12dB GR, dialogue priority"
+            },
+            "proTip": "Create genre-specific compressor presets with appropriate settings for pop, EDM, hip-hop, etc., so you can quickly apply genre-appropriate sidechaining in future projects.",
+            "avoidThis": "Don't apply heavy EDM-style pumping to rock or acoustic genres—it will sound unnatural and out of place. Match your sidechaining intensity to genre conventions.",
+            "checkYourWork": "Your sidechaining matches the intensity and character expected in your genre. If unsure, A/B your mix against professional references.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step16_genre_comparison.png"
+          },
+          {
+            "number": 57,
+            "title": "Automating Sidechain Intensity",
+            "concept": "Automating sidechain parameters across song sections creates dynamic intensity changes—subtle in verses, heavy in choruses—for evolving energy.",
+            "actions": [
+              "Identify sections where sidechain intensity should change (e.g., lighter verse, heavier chorus).",
+              "Automate the compressor's threshold, ratio, or mix control.",
+              "Use snapshots or automation lanes to create smooth transitions.",
+              "Match sidechain intensity to arrangement density and energy."
+            ],
+            "body": "Static sidechain settings throughout an entire song can feel monotonous or inappropriate—verses may need subtle ducking while choruses benefit from heavier pumping. Automating sidechain parameters lets you dynamically adjust intensity to match the song's emotional and arrangement arc.\n\nCommon automation targets:\n\n**Threshold Automation:** Raising the threshold reduces how much the compressor engages (less ducking). Lowering it increases ducking. Automate threshold up during verses for minimal pumping, down during choruses for obvious pumping.\n\n**Ratio Automation:** Lower ratio (2:1 to 4:1) for transparent sections, higher ratio (6:1 to 10:1) for aggressive sections. This changes the intensity of gain reduction without altering when the compressor engages.\n\n**Mix Control Automation (Parallel Sidechaining):** Many compressors offer a 'Mix' or 'Dry/Wet' control that blends the compressed signal with the unprocessed signal. Automate this from 0% (no sidechaining) in quiet sections to 100% (full sidechaining) in heavy sections.\n\n**Attack/Release Automation:** Less common, but you can automate attack/release for changing character—fast attack in verses for tight control, slower attack in choruses for more natural pumping.\n\nWorkflow:\n\n1. Set up your sidechain compression with settings appropriate for the most intense section (usually the chorus or drop).\n\n2. In Logic Pro's automation view, enable automation for the parameter you want to control (threshold, ratio, or mix).\n\n3. Create automation lanes for each section:\n   - Intro: Minimal sidechaining (high threshold or low mix)\n   - Verse: Subtle sidechaining (moderate threshold)\n   - Pre-Chorus: Building intensity (lower threshold)\n   - Chorus: Maximum sidechaining (lowest threshold or highest mix)\n   - Bridge: Variable based on arrangement\n   - Outro: Fade sidechaining intensity to match energy decline\n\n4. Use smooth automation curves (not abrupt steps) to avoid audible jumps. Write gradual transitions that happen over 1-2 bars before section changes.\n\n5. Test the entire song to ensure the sidechain intensity feels musical and supports the arrangement's energy arc.\n\nThis technique is standard in professional pop and EDM production. Choruses often have obvious pumping while verses are clean and stable. This dynamic intensity change reinforces the song's structure and creates evolving energy that keeps listeners engaged.\n\nAdvanced approaches:\n- **Automation Snapshots:** Save different compressor settings as snapshots, then automate switching between them at section boundaries.\n- **Bus-Level Automation:** If using bus-based sidechaining (Step 15), automate the bus compressor's parameters for cohesive intensity changes across all grouped tracks.\n- **Parallel Sidechaining:** Create two buses—one heavily sidechained, one not. Automate the balance between them for smooth intensity transitions.",
+            "symbolName": "slider.horizontal.2.rectangle.and.arrow.triangle.2.circlepath",
+            "visualTitle": "Automating Sidechain Intensity",
+            "visualCaption": "Dynamic ducking that evolves with the song.",
+            "settings": {
+              "Threshold Automation": "High (less ducking) → Low (more ducking)",
+              "Ratio Automation": "2:1 (subtle) → 8:1 (obvious)",
+              "Mix Automation": "0% (off) → 100% (full effect)",
+              "Section-Based": "Verse: subtle, Chorus: heavy"
+            },
+            "proTip": "Automate sidechain intensity to build energy into drops and breakdowns—increase pumping gradually over 8-16 bars leading into a drop for maximum impact.",
+            "avoidThis": "Don't create abrupt, stepped automation changes—sudden shifts in sidechain intensity sound unnatural. Use smooth, gradual curves.",
+            "checkYourWork": "Sidechain intensity changes feel musical and support the song's structure. Verses are stable, choruses have appropriate energy, and transitions are smooth.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step17_automation.png"
+          },
+          {
+            "number": 58,
+            "title": "Parallel Sidechaining: Blending Ducked and Unducked Signals",
+            "concept": "Blending a sidechained version of a track with the unprocessed original creates controlled ducking without losing energy or presence.",
+            "actions": [
+              "Duplicate your target track or route it to a parallel aux.",
+              "Apply aggressive sidechain compression to the duplicate/aux.",
+              "Blend the heavily ducked signal with the dry original for hybrid control.",
+              "Adjust the balance to achieve the desired ducking intensity."
+            ],
+            "body": "Parallel sidechaining is a technique where you blend a heavily sidechained version of a track with the original, unprocessed version. This creates a hybrid sound where you get the clarity and space benefits of sidechaining without completely losing the track's energy and presence. It's especially useful for maintaining low-end power while still allowing kick clarity.\n\nConcept:\n- The original track stays at full volume, maintaining energy and presence.\n- The sidechained duplicate ducks dramatically when the trigger (e.g., kick) plays.\n- Blending the two creates a sound that's 'mostly there' but with subtle ducking—less obvious than pure sidechain compression, but more effective than no sidechaining.\n\nSetup Method 1: Duplicate Track\n\n1. Duplicate your target track (e.g., bass). Name one 'Bass Dry' and one 'Bass SC.'\n\n2. On the 'Bass SC' track, apply aggressive sidechain compression (8:1 ratio, 10-15dB gain reduction, fast attack, tempo-synced release).\n\n3. Leave the 'Bass Dry' track completely unprocessed (no sidechaining).\n\n4. Balance the two tracks by adjusting their faders:\n   - More 'Bass Dry' = more energy, less ducking.\n   - More 'Bass SC' = more obvious ducking, cleaner kick-bass interaction.\n   - Typical balance: 60% dry, 40% sidechained, but adjust to taste.\n\n5. Group the two tracks for easy level control.\n\nSetup Method 2: Aux Send (True Parallel)\n\n1. Keep your bass track at full volume with no sidechaining.\n\n2. Create an auxiliary track. Name it 'Bass SC Parallel.'\n\n3. Insert an aggressive sidechain compressor on the aux, sidechained to your kick.\n\n4. Send your bass track to this aux via a post-fader send.\n\n5. Blend the aux return level to taste—lower for subtle parallel ducking, higher for more obvious effect.\n\nBenefits:\n- **Maintains Energy:** The dry signal keeps the track feeling powerful and present.\n- **Provides Clarity:** The sidechained signal creates space for the kick without sacrificing too much low-end fullness.\n- **Adjustable Intensity:** You can dial in exactly how much ducking you want by adjusting the blend.\n- **Cleaner Than Moderate Settings:** Often cleaner and more musical than trying to find the 'perfect' moderate sidechain settings on a single track.\n\nApplications:\n- **Kick-Bass:** Parallel sidechaining maintains bass power while allowing kick clarity.\n- **Vocal Clarity:** Blend a heavily ducked music bus with a lightly ducked (or undocked) version for subtle vocal space without obvious pumping.\n- **Creative Pumping:** Use extreme sidechaining on the parallel channel for obvious pumping while the dry signal keeps the track grounded.\n\nAdvanced variations:\n- **Multiband Parallel:** Apply heavy low-end sidechaining on the parallel channel while leaving mids/highs dry.\n- **Frequency-Split Parallel:** Duplicate the track, high-pass the dry version (keeping only upper harmonics), low-pass the sidechained version (keeping only the fundamental), then blend. This lets the bass's 'body' stay present while only the fundamental ducks.\n- **NY Compression + Sidechain:** Combine traditional parallel compression (for density) with parallel sidechaining (for space) for hybrid control.",
+            "symbolName": "arrow.triangle.branch",
+            "visualTitle": "Parallel Sidechaining",
+            "visualCaption": "Blend ducked and dry for hybrid control.",
+            "settings": {
+              "Dry Signal": "100% level, no processing",
+              "Sidechained Signal": "Aggressive settings (8:1, 10-15dB GR)",
+              "Typical Blend": "60% dry, 40% sidechained (adjust to taste)",
+              "Method": "Duplicate track or aux send/return"
+            },
+            "proTip": "Use parallel sidechaining when standard sidechain settings feel either too subtle or too aggressive—the blend gives you precise control in the 'middle ground.'",
+            "avoidThis": "Don't add processing (EQ, reverb, etc.) to only one of the parallel signals unless intentional—this can create phase or tonal imbalance. Keep both clean or process identically.",
+            "checkYourWork": "Your track maintains energy and presence while still creating space for the trigger (e.g., kick clarity without losing bass power).",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step18_parallel_sidechain.png"
+          },
+          {
+            "number": 59,
+            "title": "Using Ghost Triggers for Creative Control",
+            "concept": "Creating a silent 'ghost' trigger track—MIDI or audio—gives you complete control over sidechain rhythm without being tied to existing arrangement elements.",
+            "actions": [
+              "Create a new MIDI or audio track that outputs no sound (muted or routed to nowhere).",
+              "Program the exact rhythm you want for sidechain triggering.",
+              "Use this ghost track as the sidechain input for your compressor/gate.",
+              "Adjust the ghost track's rhythm independently of the actual arrangement."
+            ],
+            "body": "Most sidechaining uses existing arrangement elements—kick drum, hi-hat, vocal—as the trigger. But sometimes you want sidechain ducking or gating to follow a rhythm that doesn't exist in your arrangement. Ghost triggers (also called 'phantom' or 'dummy' triggers) solve this by creating a silent track whose sole purpose is to trigger sidechain processing.\n\nApplications:\n\n**Custom Rhythmic Patterns:** Create complex, syncopated pumping rhythms that aren't tied to your kick drum. For example, trigger sidechain ducking on every eighth note, creating a faster pump than the quarter-note kick provides.\n\n**Gate Sidechaining for Vocal Chopping:** Program a MIDI rhythm that 'slices' a sustained vocal into rhythmic fragments, creating stutter and glitch effects.\n\n**Independent Control:** Change the sidechain rhythm without altering the actual kick drum or drum pattern in your mix.\n\n**Pre-Production Experimentation:** Set up ghost triggers early in production to test different pumping rhythms before committing to a drum pattern.\n\nSetup Method 1: MIDI Ghost Trigger\n\n1. Create a new software instrument track in Logic Pro.\n\n2. Load a simple, percussive instrument (like Ultrabeat or a single drum sample in EXS24) or even leave it empty.\n\n3. Mute the track's output: set the track's output to 'No Output' or reduce its fader to -∞.\n\n4. Program a MIDI pattern with the exact rhythm you want for sidechain triggering. For example, quarter-note triggers, sixteenth-note hi-hat patterns, or syncopated rhythms.\n\n5. In your sidechain compressor (on the target track), set the sidechain input to this ghost MIDI track.\n\n6. The compressor will 'hear' the ghost track's rhythm and duck accordingly, even though the ghost track produces no audible sound in the mix.\n\nSetup Method 2: Audio Ghost Trigger\n\n1. Create a new audio track.\n\n2. Route its output to an unused bus (not the Stereo Output) so it produces no audible sound.\n\n3. Place audio regions (like a kick sample) with the desired rhythm.\n\n4. Use this audio track as the sidechain input for your compressor/gate.\n\nBenefits:\n- **Flexibility:** You can edit the ghost track's rhythm independently without affecting the actual arrangement.\n- **Experimentation:** Try different sidechain rhythms instantly by editing the ghost track's MIDI or audio.\n- **Precision:** Create exact, quantized, or custom rhythms that don't depend on live drum performance timing.\n- **Layered Sidechaining:** Use multiple ghost triggers with different rhythms for different sidechain targets (one ghost for kick-style pumping, another for hi-hat-style gating).\n\nAdvanced techniques:\n- **Ghost Velocity Automation:** Program MIDI velocity changes on the ghost track to create dynamic sidechain intensity—louder ghost notes trigger more compression, quieter notes trigger less.\n- **Ghost Track Effects:** Apply effects (reverb, delay) to the ghost trigger (before muting its output) to create 'smeared' or 'trailing' sidechain triggers for experimental effects.\n- **Multiple Ghost Tracks:** Create separate ghost triggers for different sidechain targets—one for kick-style pumping (quarter notes), one for hi-hat gating (sixteenth notes), one for custom rhythmic effects.",
+            "symbolName": "waveform.badge.magnifyingglass",
+            "visualTitle": "Ghost Trigger Control",
+            "visualCaption": "Silent trigger tracks for custom rhythms.",
+            "settings": {
+              "MIDI Ghost": "Software instrument track, output muted or to 'No Output'",
+              "Audio Ghost": "Audio track routed to unused bus (not Stereo Out)",
+              "Rhythm": "Program exact pattern for sidechain triggering",
+              "Use Cases": "Custom pumping, vocal chopping, experimental gating"
+            },
+            "proTip": "Use a simple, short sample (like a single kick or click) on your ghost trigger track for clean, consistent triggering. Avoid complex, sustained sounds which may cause erratic compressor response.",
+            "avoidThis": "Don't forget to mute or re-route the ghost track's output—if it's audible in your mix, it will create unwanted clicks or drum sounds.",
+            "checkYourWork": "Your sidechain processing follows the exact custom rhythm you programmed, independent of the actual arrangement. The ghost track produces no audible sound.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step19_ghost_trigger.png"
+          },
+          {
+            "number": 60,
+            "title": "Final Checklist and Best Practices",
+            "concept": "A final review of sidechaining best practices ensures your implementation is clean, musical, and appropriate for your production goals.",
+            "actions": [
+              "Review all sidechain instances to verify appropriate intensity and settings.",
+              "Check for artifacts: clicks, pumping, distortion, or unnatural movement.",
+              "Test your mix in mono, at low volume, and on multiple playback systems.",
+              "Verify sidechain processing serves the music, not just the technique."
+            ],
+            "body": "Before finalizing your mix, run through this comprehensive sidechaining checklist to ensure professional results:\n\n**1. Verify Signal Routing:**\n- Confirm every sidechain compressor/gate is receiving the correct trigger source.\n- Check that target tracks are being affected (watch the gain-reduction meter).\n- Ensure no accidental routing to Stereo Out or unintended buses.\n\n**2. Check for Artifacts:**\n- Listen for clicks or pops (indicates attack/release too fast).\n- Listen for harsh, unmusical pumping (reduce ratio or raise threshold).\n- Listen for distortion or harshness (reduce gain reduction or change compressor type).\n- Listen for phase issues or hollow sound (check correlation meter, especially in mono).\n\n**3. Test Across Playback Systems:**\n- Check in mono: does the sidechaining translate well or cause problems?\n- Check at low volume: is the ducking still audible and appropriate?\n- Check on earbuds/phone speakers: does the low-end management still work?\n- Check on studio monitors: is the effect too obvious or too subtle?\n\n**4. Verify Musical Appropriateness:**\n- Does the sidechaining support the genre? (Transparent for pop, obvious for EDM, functional for podcasts)\n- Does it support the song's energy arc? (Subtle in verses, heavier in choruses, or consistent throughout?)\n- Does it solve a real problem (masking, clutter, lack of space) or is it arbitrary?\n\n**5. Review Intensity Across All Instances:**\n- If using multiple sidechain compressors, do they all use appropriate settings for their role?\n- Are some elements over-sidechained (losing energy) while others are under-sidechained (still masking)?\n- Is the overall mix stable, or does excessive sidechaining make everything feel pumping and unstable?\n\n**6. Bypass Test:**\n- Bypass all sidechain compressors at once and compare to the sidechained version.\n- The sidechained version should sound clearly better (clearer, more spacious, better separation).\n- If bypassing sounds better, you've over-sidechained—reduce intensity or remove unnecessary instances.\n\n**7. CPU and Session Management:**\n- Verify CPU load is reasonable (bus-based sidechaining helps if CPU is high).\n- Name all sidechain compressors clearly ('SC to Kick,' 'SC to Vocal') for easy troubleshooting.\n- Document your sidechain routing in session notes if the session is complex.\n\n**8. Genre-Specific Final Checks:**\n- **Pop/Rock:** Vocals clear? Low end tight? No obvious pumping in melodic elements?\n- **EDM:** Pumping obvious and musical? Tempo-synced and groovy? Energy maintained?\n- **Hip-Hop:** Kick-bass separation clean? Upper mix stable?\n- **Podcast:** Dialogue 100% intelligible? Background ducks appropriately?\n\n**9. Automation Review:**\n- If using sidechain automation, verify smooth transitions between sections.\n- Ensure automation curves are gradual, not stepped (which causes audible jumps).\n\n**10. Final Reference Check:**\n- A/B your mix against professional references in your genre.\n- Does your sidechaining match the intensity and character of those references?\n\nBest Practices Summary:\n- **Start subtle, add intensity only if needed.** It's easier to add more sidechaining than to undo over-sidechaining.\n- **Use bus-based sidechaining** for CPU efficiency and cohesion in complex sessions.\n- **Match genre expectations.** Don't apply EDM pumping to jazz, or subtle pop sidechaining to house music.\n- **Use dynamic EQ or multiband sidechaining** for transparent, surgical space creation.\n- **Test in mono and at low volume** to verify translation.\n- **Sidechain EQ filtering** improves triggering consistency and reduces artifacts.\n- **Automate sidechain intensity** to match song sections and energy arc.\n- **Reference professional tracks** before finalizing your sidechaining decisions.\n\nSidechaining is one of the most powerful tools in modern mixing and production. When done well, it creates space, clarity, and movement that elevates your mix. When done poorly, it creates pumping, instability, and listener fatigue. Following this checklist ensures you land on the professional side of that divide.",
+            "symbolName": "checkmark.seal.fill",
+            "visualTitle": "Sidechaining Best Practices",
+            "visualCaption": "Final checklist for clean, professional results.",
+            "settings": {
+              "Routing": "Verify all sidechain sources and targets",
+              "Artifacts": "No clicks, harshness, or unnatural pumping",
+              "Translation": "Test mono, low volume, multiple systems",
+              "Musical Fit": "Supports genre, song structure, and energy",
+              "Bypass Test": "Sidechained version clearly better"
+            },
+            "proTip": "Create a 'Sidechain Template' session with pre-configured buses, compressors, and routing for your typical workflow. This speeds up future projects and ensures consistent, professional results.",
+            "avoidThis": "Don't assume your sidechaining is correct without testing—bypass and compare, check in mono, and verify on multiple systems before calling a mix finished.",
+            "checkYourWork": "Your sidechaining is clean, musical, genre-appropriate, and translates well across playback systems. It solves real problems without introducing new ones.",
+            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step16_genre_comparison.png"
+          }
+        ]
+      },
+      {
+        "id": "parallel-busses",
+        "title": "Parallel Busses: Advanced Mixing Technique",
+        "series": "Advanced Mixing Series",
+        "summary": "Learn practical parallel routing in Logic Pro for compression, saturation, and time-based effects while preserving transient clarity and musical dynamics.",
+        "duration": "28 min read",
+        "symbolName": "arrow.triangle.branch",
+        "badges": [
+          "Advanced",
+          "Creative",
+          "Technique"
+        ],
+        "isFeatured": true,
+        "checklist": [
+          "Create dedicated parallel aux buses and name them clearly.",
+          "Use pre-fader sends when you need independent blend control.",
+          "Set up parallel compression to add density without flattening transients.",
+          "Use EQ on returns to keep low-end and harshness controlled.",
+          "Level-match and A/B returns against the dry signal.",
+          "Check phase and mono compatibility before finalizing."
+        ],
+        "steps": [
+          {
+            "number": 1,
+            "title": "Understand the Parallel Workflow",
+            "concept": "Parallel processing blends a heavily processed duplicate with the original to gain impact without sacrificing natural tone.",
+            "actions": [
+              "Keep your dry source intact.",
+              "Route a send to a dedicated aux return.",
+              "Blend processed return until it supports the source."
+            ],
+            "body": "This approach lets you use aggressive settings (compression, distortion, filtering) while preserving clarity from the dry path.",
+            "symbolName": "arrow.triangle.branch",
+            "visualTitle": "Dry + Processed Blend",
+            "visualCaption": "Power and control without destroying source detail.",
+            "settings": {
+              "Starting Blend": "10-30% return level",
+              "Signal Flow": "Dry track + aux return"
+            },
+            "proTip": "Set up reusable parallel aux templates for speed across sessions.",
+            "avoidThis": "Do not over-blend returns until the dry source disappears.",
+            "checkYourWork": "Bypassing the return reduces impact, but the mix still sounds natural.",
+            "stepScreenshot": "/assets/training/parallel-busses/step1_concept_diagram.png"
+          },
+          {
+            "number": 2,
+            "title": "Route Parallel Compression",
+            "concept": "Parallel compression adds body and sustain while leaving transient attack intact.",
+            "actions": [
+              "Send drum or vocal bus to an aux with a compressor.",
+              "Use higher ratio and deeper gain reduction than you would in serial mode.",
+              "Blend the return under the dry signal."
+            ],
+            "body": "On drums, this increases perceived power. On vocals, it can improve consistency and intelligibility in dense sections.",
+            "symbolName": "arrow.down.circle.fill",
+            "visualTitle": "Crush Then Blend",
+            "visualCaption": "Aggressive return, subtle mix contribution.",
+            "settings": {
+              "Typical Ratio": "6:1 to 12:1",
+              "Gain Reduction": "8-15 dB on return path"
+            },
+            "proTip": "Shape return tone with EQ after compression to avoid mud.",
+            "avoidThis": "Avoid stacking multiple parallel compressors without purpose.",
+            "checkYourWork": "The return adds energy and sustain without pumping artifacts.",
+            "stepScreenshot": "/assets/training/parallel-busses/step3_drum_compression.png"
+          },
+          {
+            "number": 3,
+            "title": "Use Parallel Reverb and Saturation",
+            "concept": "Parallel time and harmonic effects create size and color while maintaining source focus.",
+            "actions": [
+              "Use separate aux returns for short room, plate, and saturation.",
+              "Filter reverb returns to control low-end wash.",
+              "Automate return levels for transitions and choruses."
+            ],
+            "body": "Parallel reverbs improve depth without clouding the center. Parallel saturation improves perceived loudness and texture.",
+            "symbolName": "sparkles",
+            "visualTitle": "Depth and Harmonics",
+            "visualCaption": "Space and color under the dry signal.",
+            "settings": {
+              "HPF on Reverb Return": "150-300 Hz",
+              "Return Strategy": "Separate aux by effect type"
+            },
+            "proTip": "Short reverbs often read cleaner than long tails in busy arrangements.",
+            "avoidThis": "Do not feed every track into every return bus.",
+            "checkYourWork": "Mix feels wider and richer while lead elements stay clear.",
+            "stepScreenshot": "/assets/training/parallel-busses/step4_reverb_routing.png"
+          },
+          {
+            "number": 4,
+            "title": "Validate Phase and Translation",
+            "concept": "Parallel chains can introduce phase and masking if unchecked.",
+            "actions": [
+              "A/B dry-only vs blend at matched loudness.",
+              "Check mono fold-down for cancellations.",
+              "Trim return timing/phase if low-end weakens."
+            ],
+            "body": "Final checks ensure parallel benefits survive across speakers, headphones, and mono playback.",
+            "symbolName": "checkmark.seal.fill",
+            "visualTitle": "Final Safety Pass",
+            "visualCaption": "Phase-safe, mono-safe, mix-safe.",
+            "settings": {
+              "A/B Method": "Matched loudness comparison",
+              "Mono Check": "No major center collapse"
+            },
+            "proTip": "Keep one reference snapshot with all returns bypassed.",
+            "avoidThis": "Avoid judging return tone in solo for final decisions.",
+            "checkYourWork": "Parallel processing improves excitement and still translates cleanly.",
+            "stepScreenshot": "/assets/training/parallel-busses/step10_complete_workflow.png"
+          }
+        ]
+      },
+      {
+        "id": "stereo-tricks",
+        "title": "Stereo Tricks",
+        "series": "Advanced Mixing Techniques",
+        "summary": "Master professional stereo imaging techniques to create width, depth, and space in your mixes. Learn panning strategies, mid-side processing, the Haas effect, double tracking, and advanced Logic Pro stereo tools for mono-compatible, immersive productions.",
+        "duration": "35 min read",
+        "symbolName": "speaker.wave.3.fill",
+        "badges": [
+          "Advanced",
+          "Professional",
+          "Mixing"
+        ],
+        "isFeatured": true,
+        "checklist": [
+          "Understand the stereo field and placement zones for different instruments.",
+          "Master Logic Pro's pan controls and pan law settings.",
+          "Use the Direction Mixer for precise stereo width control.",
+          "Apply mid-side processing for independent center and side channel shaping.",
+          "Implement the Haas effect correctly for stereo width.",
+          "Record effective double-tracked parts for natural width.",
+          "Create complex stereo delay patterns with Logic's Stereo Delay.",
+          "Monitor phase correlation to ensure mono compatibility.",
+          "Use frequency-dependent stereo processing with Split mode.",
+          "Apply stereo automation for dynamic width changes.",
+          "Avoid common stereo mistakes that cause phase issues.",
+          "Verify mixes in both mono and stereo playback."
+        ],
+        "steps": [
+          {
+            "number": 1,
             "title": "Understanding the Stereo Field",
             "concept": "The stereo field is the perceived horizontal space between left and right speakers where you position sounds in your mix.",
             "actions": [
@@ -12199,7 +13334,7 @@
             "proTip": "Use Direction Mixer's Spread control between 0-100% to narrow overly-wide stereo samples so they fit better in dense mixes, rather than just lowering their volume.",
             "avoidThis": "Don't push Spread above 150% on bass-heavy material—extreme widening at low frequencies causes phase cancellation and weak mono translation.",
             "checkYourWork": "Your stereo sources have the exact width and position you intend, and they maintain clarity and power both in stereo and when checked in mono.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step5_spread_comparison.png"
+            "stepScreenshot": "/assets/training/stereo-tricks/step4_direction_mixer.png"
           },
           {
             "number": 5,
@@ -12599,729 +13734,6 @@
             "proTip": "Automate width on your drum bus to make choruses feel bigger—narrow slightly in verses (90%), widen in choruses (110%)—subtle but effective for creating section contrast.",
             "avoidThis": "Don't automate width on bass frequencies or core elements—width automation works best on pads, atmospheres, background vocals, and supporting elements, not foundation elements.",
             "checkYourWork": "Your width automation creates noticeable energy and contrast between sections, transitions smoothly without artifacts, and maintains mono compatibility at all automation points.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step22_stereo_automation.png"
-          },
-          {
-            "number": 23,
-            "title": "Understanding Sidechaining Fundamentals",
-            "concept": "Sidechaining uses one audio signal to control the behavior of a processor on another track, creating dynamic space and movement in your mix.",
-            "actions": [
-              "Learn the signal flow: source track (trigger) controls processor on target track (affected).",
-              "Understand the difference between transparent mixing sidechaining and creative effect sidechaining.",
-              "Identify which Logic Pro plugins support sidechain input."
-            ],
-            "body": "Sidechaining is a routing technique where one audio signal—the 'trigger' or 'key' signal—controls a processor on a different track. The most common application is sidechain compression, but Logic Pro supports sidechaining with compressors, gates, auto-filters, and several synthesizers.\n\nThe fundamental concept is this: instead of a processor responding to the audio on its own track, it responds to audio from somewhere else. When a kick drum plays, sidechain compression on the bass track 'hears' that kick and compresses the bass at that moment, creating space for the kick to cut through.\n\nThere are two broad philosophical approaches to sidechaining:\n\n**Transparent Sidechaining (Mixing):** The goal is clarity and space without obvious artifacts. You want elements to coexist without frequency masking, but you don't want listeners to consciously notice the ducking. This is common in professional pop, rock, hip-hop, and film mixing. Settings are gentle: low ratios (2:1 to 4:1), moderate attack, release timed to musical phrases.\n\n**Creative Sidechaining (Production):** The ducking effect is deliberate and obvious, often rhythmic and exaggerated. This is the 'pumping' sound in EDM, French house, and modern pop. Settings are aggressive: high ratios (8:1 to ∞:1), fast attack, release synchronized to tempo. The effect becomes part of the arrangement's character.\n\nIn Logic Pro, the following plugins support sidechain input:\n- Compressor (all types including Vintage models)\n- Noise Gate\n- Expander\n- Auto Filter\n- Enveloper\n- EVOC 20 TrackOscillator\n- ES2, Sculpture, and EVOC 20 PolySynth (for synthesis applications)\n\nThird-party plugins like FabFilter Pro-C 2, FabFilter Pro-Q 3 (dynamic EQ), Trackspacer, Soothe 2, and Waves C1 also offer advanced sidechain features, though Logic's stock tools are fully capable for most tasks.\n\nThe sidechaining workflow always follows this pattern:\n1. Place the processor (compressor, gate, etc.) on the track you want to affect (target).\n2. In the processor's interface, locate the Sidechain or 'Side Chain' menu (usually top-right corner).\n3. Select the track or bus you want to use as the trigger source.\n4. Adjust the processor's parameters to achieve your desired response.\n\nSidechaining is one of the most powerful tools in modern mixing and production. It solves frequency masking problems, creates space for vocals and lead elements, automates dynamic changes that would be tedious to write manually, and generates creative rhythmic movement. Understanding when and how to apply it separates amateur mixes from professional ones.",
-            "symbolName": "point.3.filled.connected.trianglepath.dotted",
-            "visualTitle": "Sidechain Signal Flow",
-            "visualCaption": "Source signal controls target processor.",
-            "settings": {
-              "Transparent Settings": "Ratio 2:1-4:1, moderate attack/release",
-              "Creative Settings": "Ratio 8:1+, fast attack, tempo-synced release",
-              "Supported Plugins": "Compressor, Gate, Auto Filter, and more"
-            },
-            "proTip": "When learning sidechaining, start with obvious, exaggerated settings so you can clearly hear what's happening. Once you understand the behavior, dial back the intensity for transparent mixing results.",
-            "avoidThis": "Don't apply sidechaining to every track by default. Use it to solve specific problems or create intentional effects—overuse creates an unstable, pumping mix where nothing feels anchored.",
-            "checkYourWork": "You can explain the signal flow of sidechaining and identify which track is the trigger and which is the target.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step1_sidechain_concept.png"
-          },
-          {
-            "number": 2,
-            "title": "Classic Application: Kick-Bass Ducking",
-            "concept": "Sidechaining bass to kick drum creates low-end clarity by temporarily reducing bass volume when the kick hits, preventing frequency masking in the 40-80Hz range.",
-            "actions": [
-              "Place a compressor on your bass track.",
-              "Set the compressor's sidechain input to your kick drum track.",
-              "Use fast attack (0.1-5ms), moderate ratio (3:1-6:1), and release timed to groove (50-150ms).",
-              "Adjust threshold until you see 3-6dB of gain reduction on each kick hit."
-            ],
-            "body": "The kick drum and bass guitar (or synth bass) both occupy the critical low-frequency range between 40Hz and 80Hz. When both play simultaneously, they compete for the same physical space in speakers and headphones, creating a muddy, undefined low end. This is a fundamental physics problem: a speaker cone can only move in one direction at a time, so overlapping low-frequency signals either reinforce (if perfectly in phase) or cancel each other (if out of phase). More commonly, they simply blur together into indistinct rumble.\n\nSidechain compression solves this by briefly reducing the bass level whenever the kick drum plays, giving the low-end frequency spectrum to the kick during its transient and fundamental tone. As the kick's energy fades, the bass swells back up to fill the space. When done well, the listener doesn't consciously hear ducking—they just hear a tight, punchy low end where kick and bass feel locked together.\n\nHere's the step-by-step setup:\n\n1. Insert Logic's Compressor plugin on your bass track (audio or software instrument).\n\n2. In the compressor interface, locate the 'Side Chain' drop-down menu in the top-right section. Click it and select your kick drum track from the list. If your kick is bussed or part of a drum group, you can select that bus instead.\n\n3. Set the compressor's Attack to 0.1ms to 5ms. You want the compression to engage the instant the kick transient arrives. Fast attack ensures the bass ducks immediately, preventing overlap.\n\n4. Set the Ratio to 3:1 or 4:1 for transparent mixing, or 6:1 to 8:1 if you want more obvious ducking (common in EDM or hip-hop). Higher ratios mean more aggressive volume reduction.\n\n5. Set the Release time based on your track's tempo and groove. For fast dance music (120-128 BPM), try 50ms to 80ms. For slower hip-hop or R&B (80-100 BPM), try 100ms to 150ms. The goal is for the bass to swell back to full volume just as the next kick is about to hit, creating a rhythmic pumping that grooves with the track.\n\n6. Adjust the Threshold until you see the gain-reduction meter showing 3dB to 6dB of reduction on each kick hit. Too much reduction (10dB+) makes the ducking obvious and can kill the bass's energy. Too little (1dB or less) may not solve the masking problem.\n\n7. Leave the Knee at its default (moderate/soft) for most applications. Hard knee creates more obvious compression; soft knee is smoother.\n\n8. Do not add makeup gain on the bass compressor—you're intentionally creating volume reduction here, not trying to make the bass louder overall.\n\n9. Check your mix in mono and at low volume. The kick should feel punchy and defined, and the bass should feel rhythmic and present without fighting the kick.\n\nThis technique is a foundational skill in modern production. It's used on virtually every professional EDM, pop, and hip-hop track. Even rock and metal mixes benefit from subtle kick-bass sidechaining to clean up the low end, though the effect is usually more transparent in those genres.\n\nCommon variations:\n- If your kick has a long tail or sub-bass that extends beyond the transient, adjust the release to match that decay.\n- If the ducking feels too obvious, reduce the ratio or increase the threshold (which reduces how much the compressor engages).\n- For electronic music with perfectly quantized, four-on-the-floor kicks, you can use a volume shaper plugin like LFO Tool or Cableguys ShaperBox instead of a compressor. These let you literally draw the volume curve, avoiding compression artifacts entirely.",
-            "symbolName": "waveform.path",
-            "visualTitle": "Kick-Bass Ducking Setup",
-            "visualCaption": "Bass ducks when kick hits.",
-            "settings": {
-              "Attack": "0.1-5ms (instant response)",
-              "Release": "50-150ms (tempo/groove dependent)",
-              "Ratio": "3:1 to 6:1 (transparent to obvious)",
-              "Gain Reduction Target": "3-6dB per kick hit"
-            },
-            "proTip": "Set your compressor's release time by playing the track and adjusting the knob until the gain-reduction meter 'breathes' with the rhythm—bouncing down and recovering in sync with the groove.",
-            "avoidThis": "Don't set threshold so low that the compressor is always compressing, even when the kick isn't playing. The bass should return to full volume between kicks.",
-            "checkYourWork": "Your kick drum is punchy and clear, the bass has rhythmic movement, and the low end sounds tight in both stereo and mono playback.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step2_kick_bass_compressor.png"
-          },
-          {
-            "number": 3,
-            "title": "Visual Analysis: Kick-Bass Interaction",
-            "concept": "Understanding the waveform and frequency interaction between kick and bass helps you visualize what sidechaining accomplishes.",
-            "actions": [
-              "Use a spectrum analyzer to see frequency overlap between kick and bass.",
-              "Observe the gain-reduction meter on the bass compressor to verify ducking timing.",
-              "Compare the waveform before and after sidechain compression to see the volume reduction."
-            ],
-            "body": "Visual feedback is essential for dialing in effective kick-bass sidechaining. Logic Pro's built-in metering, along with the Channel EQ's analyzer and third-party spectrum analyzers, help you see what's happening in the frequency spectrum.\n\nBefore sidechaining, place Logic's Channel EQ on both the kick and bass tracks (set to Analyzer mode without making EQ changes). Play the section where kick and bass play together. You'll see both tracks' energy concentrated in the 40-80Hz range, with peaks likely overlapping. This overlap is where masking occurs—both sounds are fighting for the same frequency space.\n\nAfter setting up sidechain compression, watch the gain-reduction meter on the bass compressor. You should see the meter respond rhythmically, showing 3-6dB of reduction each time the kick hits, then releasing back to zero before the next kick. If the meter shows constant compression (never fully releasing), your threshold is too low. If it barely moves, your threshold is too high or your ratio is too gentle.\n\nIn the Arrange window, you can visually compare the bass waveform before and after sidechaining by duplicating the bass track, applying sidechain compression to one, and bouncing both to audio for side-by-side comparison. The sidechained version will show distinct 'dips' in amplitude aligned with each kick hit.\n\nSome producers use oscilloscope plugins (like s(M)exoscope or Youlean Loudness Meter's waveform view) to see the actual waveform interaction in real-time. When kick and bass are properly sidechained, you'll see the bass waveform 'duck' or reduce in amplitude precisely when the kick waveform appears.\n\nThis visual approach is especially helpful when learning sidechaining. Once you develop an ear for it, you'll rely more on listening, but visual confirmation speeds up the learning process and helps troubleshoot problems like incorrect release timing or insufficient gain reduction.",
-            "symbolName": "chart.xyaxis.line",
-            "visualTitle": "Frequency Spectrum Analysis",
-            "visualCaption": "See the overlap and the solution.",
-            "settings": {
-              "Key Frequency Range": "40-80Hz (kick/bass fundamental)",
-              "Visual Tools": "Channel EQ analyzer, gain-reduction meter, spectrum analyzer",
-              "Metering Goal": "3-6dB GR on kick hits, full release between"
-            },
-            "proTip": "Use Logic's 'Split by Channel' feature on a stereo analyzer to compare kick and bass frequencies side-by-side, making overlap immediately obvious.",
-            "avoidThis": "Don't rely solely on visual metering—always use your ears to verify that the ducking feels musical and grooves with the track.",
-            "checkYourWork": "You can see the frequency overlap before sidechaining and observe the gain-reduction meter responding rhythmically after sidechaining.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step3_spectrum_analysis.png"
-          },
-          {
-            "number": 4,
-            "title": "Vocal Clarity: Music Bus Sidechaining",
-            "concept": "Routing melodic instruments through a sidechain-compressed bus triggered by vocals creates transparent space for lyrics without obvious ducking.",
-            "actions": [
-              "Create an auxiliary track and route guitars, keys, pads, and backing vocals to it.",
-              "Insert a compressor on the aux track and set its sidechain input to the lead vocal.",
-              "Use gentle settings: 3:1 to 4:1 ratio, 5-10ms attack, 80-150ms release.",
-              "Target 1-3dB of gain reduction during vocal phrases."
-            ],
-            "body": "One of the most powerful but under-discussed applications of sidechaining is creating space for lead vocals by gently compressing the entire musical bed when the vocal is present. This technique is standard in professional pop, rock, and hip-hop mixing, but it's so transparent that most listeners never consciously notice it.\n\nThe problem: when a dense arrangement plays—full band with guitars, keys, pads, synths, backing vocals—the lead vocal can get masked, especially in the 1kHz to 3kHz range where vocal intelligibility lives. You could boost the vocal with EQ or simply turn it up, but this often makes it feel disconnected from the track. Instead, subtly reducing everything else when the vocal is present makes the vocal feel embedded in the mix while remaining clear.\n\nHere's the setup:\n\n1. Create a new auxiliary (bus) track. Name it something like 'Music Bus' or 'Sidechain Aux.'\n\n2. Route all melodic and harmonic tracks to this aux. This typically includes: electric guitars, acoustic guitars, keyboards, synths, pads, strings, backing vocals, and any other mid-range-heavy elements. Do NOT route drums, bass, or lead vocals to this bus—those stay independent.\n\n3. Insert Logic's Compressor on the Music Bus aux track.\n\n4. In the compressor, set the Side Chain input to your lead vocal track.\n\n5. Configure the compressor with these settings:\n   - Ratio: 3:1 to 4:1 (gentle, transparent)\n   - Attack: 5ms to 10ms (fast enough to respond to vocal transients, but not so fast that it creates artifacts)\n   - Release: 80ms to 150ms (should recover between vocal phrases, not during sustained notes)\n   - Knee: Soft (for smooth, gradual compression)\n   - Threshold: adjust until you see 1dB to 3dB of gain reduction when the vocal is singing. During instrumental breaks (no vocal), the compressor should show zero gain reduction.\n\n6. Do not add makeup gain—you want the music to genuinely get quieter when the vocal is present.\n\n7. Solo the vocal and the music bus together, then play a dense section (like a chorus with full instrumentation). You should hear the music subtly 'breathe' around the vocal—ducking slightly when the vocal is loud, swelling back up during rests and between words.\n\nThe beauty of this technique is its transparency. If done correctly, the listener doesn't hear 'pumping' or obvious volume changes—they simply hear a vocal that's clear and present without sounding disconnected. The vocal feels 'in the pocket' of the mix.\n\nThis method is far superior to traditional automation for several reasons:\n- It's automatic: the compressor responds to every vocal phrase without manual rides.\n- It's consistent: every time that vocal phrase plays, the same amount of ducking happens.\n- It's frequency-neutral: unlike EQ, which changes tone, this simply creates dynamic space.\n\nCommon variations:\n- If the ducking is too obvious, reduce the ratio to 2:1 or raise the threshold so less compression happens.\n- If the vocal still isn't cutting through, check if your release time is too fast (causing the music to swell back up too quickly) or if your attack is too slow (letting initial consonants get masked).\n- For more surgical control, use dynamic EQ sidechaining (covered in Step 7) to target only the 1-3kHz vocal range instead of compressing the entire music bus.",
-            "symbolName": "music.note.list",
-            "visualTitle": "Music Bus Method",
-            "visualCaption": "Melodic elements duck for vocal clarity.",
-            "settings": {
-              "Ratio": "3:1 to 4:1",
-              "Attack": "5-10ms",
-              "Release": "80-150ms",
-              "Gain Reduction": "1-3dB during vocal phrases"
-            },
-            "proTip": "If your mix has both a verse and a chorus vocal, use the loudest vocal section (usually the chorus) to set your threshold. The compressor will naturally compress less during quieter verse vocals, creating dynamic variation.",
-            "avoidThis": "Don't route drums or bass to the music bus—sidechaining these creates an unstable, pumping low end. Keep the rhythm section independent.",
-            "checkYourWork": "Your lead vocal is consistently clear and intelligible without sounding louder or disconnected from the track. The music subtly breathes around the vocal.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step4_music_bus_routing.png"
-          },
-          {
-            "number": 5,
-            "title": "Podcast and Voiceover Ducking",
-            "concept": "Sidechaining background music to dialogue tracks ensures spoken words remain intelligible while maintaining atmospheric support.",
-            "actions": [
-              "Place a compressor on your background music or sound effects track.",
-              "Set the sidechain input to your dialogue or voiceover track.",
-              "Use aggressive settings for instant, obvious ducking: 8:1 ratio, <1ms attack, 200-500ms release.",
-              "Target 6-12dB of gain reduction to guarantee dialogue clarity."
-            ],
-            "body": "In podcasts, audiobooks, video production, and film mixing, dialogue clarity is paramount. Listeners need to understand every word without straining, even if background music or ambient sound effects are present. Sidechain compression automates this balance, ensuring music ducks the moment someone speaks and returns when they stop.\n\nUnlike musical sidechaining (which is often subtle), podcast/voiceover ducking is usually obvious and aggressive. The goal is not transparency—it's absolute dialogue priority. Listeners expect background elements to reduce in volume when speech is present, and this ducking is considered standard, professional behavior.\n\nSetup for podcast/voiceover ducking:\n\n1. Arrange your session with dialogue/voiceover on one track and background music/ambience on a separate track (or aux bus if you have multiple background elements).\n\n2. Insert a compressor on the background music track.\n\n3. Set the compressor's sidechain input to the dialogue track.\n\n4. Configure aggressive settings:\n   - Ratio: 8:1 to ∞:1 (limiter-style, for strong ducking)\n   - Attack: 0.1ms to 1ms (instant response to speech)\n   - Release: 200ms to 500ms (should swell back up during natural pauses, not during mid-sentence breaths)\n   - Threshold: adjust until you see 6dB to 12dB of gain reduction whenever dialogue is present. This ensures the background drops significantly, leaving room for speech.\n\n5. Test by playing sections with continuous dialogue. The background music should drop to roughly 25-40% of its normal volume, making dialogue effortlessly clear. During silent sections (no dialogue), the music should return to full volume.\n\n6. Pay special attention to the release time. If it's too fast (under 100ms), the music will pump up and down during natural speech rhythm, sounding unnatural. If it's too slow (over 1 second), the music won't return to full volume during intentional pauses or between speakers, making those pauses feel awkward.\n\nThis technique is so common in podcast production that many podcast-specific tools (like iZotope RX's Dialogue Isolate or dedicated podcast mixing plugins) include preset 'music ducking' modes that essentially automate this exact sidechain compression setup.\n\nFor video production (YouTube, corporate videos, e-learning), this same technique is used to duck background music under narration. Some video editors even automate this in post-production software (Premiere Pro, Final Cut Pro) using built-in audio ducking features, but doing it in Logic Pro during audio post-production gives you more precise control over the compression character.\n\nVariations:\n- For multi-speaker podcasts, route all dialogue tracks to a dialogue bus, then use that bus as the sidechain source. This way, background music ducks when any speaker talks.\n- For audiobooks, you might want less aggressive ducking (4:1 ratio, 3-6dB GR) if the background music is meant to remain present but supportive.\n- For film mixing, you may need to sidechain multiple background layers (music, ambience, effects) separately to the dialogue, giving you granular control over how much each element ducks.",
-            "symbolName": "mic.fill",
-            "visualTitle": "Dialogue Ducking",
-            "visualCaption": "Speech always clear over background.",
-            "settings": {
-              "Ratio": "8:1 to ∞:1",
-              "Attack": "0.1-1ms",
-              "Release": "200-500ms",
-              "Gain Reduction": "6-12dB during dialogue"
-            },
-            "proTip": "Add a high-pass filter to the sidechain input (covered in Step 11) to prevent low-frequency rumble or plosives from triggering the compressor—only mid-range speech frequencies should trigger ducking.",
-            "avoidThis": "Don't use slow attack times (over 10ms) for dialogue ducking—the first syllable of each word may get masked before the compressor engages.",
-            "checkYourWork": "Every word of dialogue is effortlessly clear, and background music feels present during pauses but never competes with speech.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step5_podcast_ducking.png"
-          },
-          {
-            "number": 6,
-            "title": "Reverb Sidechaining for Vocal Clarity",
-            "concept": "Sidechaining vocal reverb to the dry vocal prevents long, washy tails from obscuring lyrics while maintaining a sense of space.",
-            "actions": [
-              "Create a reverb send/return for vocals (aux track with reverb plugin).",
-              "Insert a compressor after the reverb on the aux return.",
-              "Set the compressor's sidechain input to the dry vocal track.",
-              "Use moderate settings: 4:1 ratio, 5-10ms attack, 50-150ms release, targeting 3-6dB GR."
-            ],
-            "body": "Reverb is essential for placing vocals in a believable acoustic space, but long reverb tails can smear lyrics and reduce intelligibility, especially in dense mixes. The traditional solution is to shorten the reverb decay time, but this sacrifices the lush, immersive quality that makes reverb effective. Sidechain compression on the reverb return offers a better solution: let the reverb ring freely during pauses and sustained notes, but duck it when new lyrics arrive.\n\nThis technique is widely used in modern pop, worship music, and ballad production. It allows for dramatic, long-decay reverbs that don't cloud fast lyrical passages.\n\nSetup:\n\n1. Create a standard reverb send/return setup: insert a Send on your lead vocal track, routing it to an auxiliary track. On that aux, insert a reverb plugin (Space Designer, ChromaVerb, or your preferred reverb).\n\n2. After the reverb plugin on the aux return, insert Logic's Compressor.\n\n3. Set the compressor's sidechain input to the dry lead vocal track (not the aux—you want the compressor to 'hear' the original vocal, not the reverb).\n\n4. Configure the compressor:\n   - Ratio: 4:1 to 6:1 (moderate, musical compression)\n   - Attack: 5ms to 10ms (fast enough to respond to new lyrics, slow enough to avoid clicks)\n   - Release: 50ms to 150ms (should release during sustained notes, not instantly)\n   - Threshold: adjust until you see 3dB to 6dB of gain reduction when the vocal is singing. The reverb should duck noticeably, but not disappear.\n\n5. Solo the vocal and reverb aux together. As the vocal sings, the reverb should reduce in level, creating space for the dry vocal. When the vocal sustains a note or pauses, the reverb should swell back up, filling the space with ambience.\n\n6. The result: you can use a 2.5-second reverb decay (which would normally blur fast lyrics) because it's being ducked when the vocal is active and only fully audible during gaps.\n\nThis technique transforms how you approach reverb in dense mixes. You're no longer limited to short, safe decay times—you can use long, lush reverbs that automatically get out of the way when needed.\n\nVariations:\n- For even more surgical control, use a dynamic EQ (like FabFilter Pro-Q 3 or Waves F6) on the reverb return, sidechained to the vocal, targeting only the 1-3kHz midrange. This ducks the 'body' of the reverb without affecting the highs or lows, preserving shimmer and depth.\n- For duet vocals, route both vocalists to the same reverb aux, then sidechain that reverb to a bus containing both vocal tracks. The reverb will duck when either singer is active.\n- If the ducking sounds too obvious, reduce the ratio to 3:1 or increase the release time so the reverb recovers more gently.",
-            "symbolName": "sparkles",
-            "visualTitle": "Reverb Sidechaining",
-            "visualCaption": "Lush reverb that doesn't smear lyrics.",
-            "settings": {
-              "Ratio": "4:1 to 6:1",
-              "Attack": "5-10ms",
-              "Release": "50-150ms",
-              "Gain Reduction": "3-6dB when vocal is active"
-            },
-            "proTip": "Use a longer release time (150ms+) for ballads and slow songs where you want the reverb to feel 'always there.' Use shorter release (50ms) for fast, rhythmic vocal passages.",
-            "avoidThis": "Don't apply this technique to every reverb in your mix—only reverbs on lead elements where clarity matters. Background vocal reverbs, for example, can usually stay untouched.",
-            "checkYourWork": "Your vocal reverb feels spacious and dramatic, but lyrics remain clear even during fast, dense passages. The reverb is most noticeable during pauses and sustained notes.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step6_reverb_sidechain.png"
-          },
-          {
-            "number": 7,
-            "title": "Delay Sidechaining for Clean Repeats",
-            "concept": "Sidechaining delay returns to the dry source prevents delay repeats from cluttering the mix during continuous performance.",
-            "actions": [
-              "Set up a delay send/return on an aux track.",
-              "Insert a compressor after the delay plugin on the aux.",
-              "Sidechain the compressor to the dry source track.",
-              "Use settings similar to reverb sidechaining: 4:1, 5ms attack, 50-150ms release."
-            ],
-            "body": "Delay effects add depth, space, and interest, but long delay tails or multiple repeats can clutter a mix, especially when the source instrument or vocal is playing continuously. Sidechaining the delay return creates a clean, professional sound where delay is audible during gaps but doesn't compete with the dry signal.\n\nThis technique is particularly useful for:\n- Vocal delays where you want distinct echoes at the end of phrases but not during active singing.\n- Guitar delays in dense rock or pop mixes.\n- Dub-style delay throws where the effect is dramatic but shouldn't mask the original performance.\n\nSetup (identical structure to reverb sidechaining):\n\n1. Create a delay send/return: insert a Send on your source track (vocal, guitar, etc.), routing to an auxiliary track. On the aux, insert a delay plugin (Delay Designer, Stereo Delay, Tape Delay, or Echo).\n\n2. After the delay plugin on the aux, insert Logic's Compressor.\n\n3. Set the compressor's sidechain input to the dry source track.\n\n4. Configure the compressor:\n   - Ratio: 4:1 to 6:1\n   - Attack: 5ms to 10ms\n   - Release: 50ms to 150ms (adjust based on delay time—longer delay times may benefit from longer release)\n   - Threshold: adjust until you see 3-6dB of gain reduction when the source is playing. The delay should duck but remain subtly audible.\n\n5. Test with a phrase that has distinct gaps. The delay repeats should be clearly audible during pauses but should sit behind the dry signal when the source is active.\n\n6. For dramatic delay throws (common in EDM, dub, and reggae), increase the ratio to 8:1 or higher so the delay almost disappears when the source plays, then swells up dramatically during gaps.\n\nThis technique is especially powerful for quarter-note or eighth-note delay settings where repeats would otherwise stack up and create rhythmic clutter. With sidechaining, you get the rhythmic interest of timed delays without the mud.\n\nVariations:\n- For ping-pong or stereo delays, apply the sidechain compression after the delay plugin but before any stereo imaging. This keeps the delay's spatial character intact while still ducking its overall level.\n- For feedback-heavy delays (where repeats go on for many cycles), sidechaining prevents the buildup from becoming overpowering.\n- For delay throws on specific words or phrases, consider automating the delay send level instead of relying on sidechaining—this gives you more surgical control over which words get delayed.",
-            "symbolName": "arrow.forward.circle",
-            "visualTitle": "Delay Sidechain Setup",
-            "visualCaption": "Clean repeats during gaps, subtle during performance.",
-            "settings": {
-              "Ratio": "4:1 to 6:1 (or 8:1+ for dramatic ducking)",
-              "Attack": "5-10ms",
-              "Release": "50-150ms",
-              "Gain Reduction": "3-6dB when source is active"
-            },
-            "proTip": "Match the compressor's release time to your delay time for musical interaction. For a quarter-note delay at 120 BPM (500ms delay), try a 200-300ms release so the delay swells back up just before the next repeat.",
-            "avoidThis": "Don't sidechain delay on every track—use it selectively where the delay would otherwise clutter the mix. Simple, short delays often don't need sidechaining.",
-            "checkYourWork": "Delay repeats are distinct and clear during pauses, but don't compete with or muddy the dry source when it's playing.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step7_delay_sidechain.png"
-          },
-          {
-            "number": 8,
-            "title": "Creative Pumping: EDM and Electronic Music",
-            "concept": "Aggressive sidechain compression with exaggerated settings creates the signature 'pumping' effect in electronic dance music.",
-            "actions": [
-              "Sidechain melodic elements (synths, pads, bass, leads) to the kick drum.",
-              "Use extreme settings: 8:1 to ∞:1 ratio, 0.1ms attack, tempo-synced release.",
-              "Target heavy gain reduction: 6-12dB or more for obvious pumping.",
-              "Experiment with release curves and timing for rhythmic character."
-            ],
-            "body": "In electronic dance music—especially house, techno, trance, and future bass—sidechain compression isn't just a mixing tool; it's a core production element. The exaggerated 'pumping' or 'breathing' effect where the entire mix rhythmically ducks around the kick drum is a deliberate aesthetic choice that creates energy, movement, and dancefloor impact.\n\nThis technique became famous in French house (Daft Punk, Justice) and is now ubiquitous in mainstream EDM. The pumping is obvious and intentional—listeners expect it and associate it with the genre.\n\nSetup for creative pumping:\n\n1. Identify which elements should pump. Typically: bass, synth pads, lead synths, plucks, and melodic elements. Drums (other than kick), vocals, and high-end percussion often stay independent for clarity.\n\n2. You can either:\n   - Place a sidechain compressor on each individual track (more control, more CPU).\n   - Route all pumping elements to a single aux bus and compress that bus (easier, more cohesive pumping).\n\n3. For individual tracks or the pumping bus, insert a compressor and set the sidechain input to your kick drum.\n\n4. Configure aggressive settings:\n   - Ratio: 8:1 to ∞:1 (limiter-style compression for maximum pumping)\n   - Attack: 0.1ms to 1ms (instant response to kick transient)\n   - Release: Tempo-synced to your track's BPM. For four-on-the-floor kicks, try setting release so the compressor fully recovers just before the next kick hit. Many compressors offer a 'Note' or 'Sync' release mode—set it to 1/4 note or 1/8 note depending on your kick pattern.\n   - Threshold: adjust until you see 10-15dB of gain reduction on each kick. You want obvious, heavy pumping.\n\n5. Listen to the groove. The pumping should feel rhythmic and musical, not arbitrary. If the release is too fast, the pump will feel abrupt and disconnected. If it's too slow, the elements won't recover before the next kick, creating a constant squashed feeling.\n\n6. The result: every time the kick hits, the entire musical bed ducks dramatically, then swells back up, creating a rhythmic 'breathing' that drives the energy of the track.\n\nMany producers use dedicated sidechain tools instead of traditional compressors for this application:\n- **Volume Shapers** (like Cableguys VolumeShaper or LFO Tool): These let you literally draw the volume envelope, giving you total control over the pump curve. You can create sharp, aggressive ducks or smooth, gentle swells.\n- **Nicky Romero Kickstart**: A plugin designed specifically for EDM-style pumping, with presets and tempo-sync features.\n- **Xfer Records LFO Tool**: Industry-standard for precise control over pumping curves.\n\nThese tools avoid compression artifacts (distortion, tone shift) because they're simply controlling volume, not actually compressing the signal. This can result in cleaner, more controlled pumping.\n\nCreative variations:\n- Pump only specific frequency ranges using multiband sidechain (covered in Step 9). For example, pump the mids and lows but leave the high-end shimmer untouched.\n- Use different release times on different elements: pump pads slowly and heavily, but pump bass quickly for a tighter feel.\n- Automate the sidechain intensity: heavy pumping during buildups and drops, lighter pumping during verses.",
-            "symbolName": "waveform.and.magnifyingglass",
-            "visualTitle": "EDM Pumping Effect",
-            "visualCaption": "Obvious, rhythmic ducking for energy.",
-            "settings": {
-              "Ratio": "8:1 to ∞:1",
-              "Attack": "0.1-1ms",
-              "Release": "Tempo-synced (1/4 or 1/8 note)",
-              "Gain Reduction": "10-15dB or more"
-            },
-            "proTip": "For the cleanest, most controlled pumping, use a volume shaper plugin instead of a compressor—you'll avoid compression artifacts and get precise control over the envelope shape.",
-            "avoidThis": "Don't pump everything including drums (other than kick) and vocals—keep some elements stable so the mix doesn't feel chaotic and unstable.",
-            "checkYourWork": "The pumping is obvious, rhythmic, and musical. It drives the energy of the track and feels locked to the groove, not arbitrary or random.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step8_edm_pumping.png"
-          },
-          {
-            "number": 9,
-            "title": "Dynamic EQ Sidechaining: Surgical Frequency Control",
-            "concept": "Sidechain-triggered dynamic EQ ducks only specific frequency ranges instead of entire tracks, creating transparent space without obvious volume changes.",
-            "actions": [
-              "Use a dynamic EQ plugin (FabFilter Pro-Q 3, Waves F6, or Logic's built-in multiband compressor as a workaround).",
-              "Set the sidechain input to the triggering track (e.g., vocal).",
-              "Target the frequency range where masking occurs (e.g., 1-3kHz for vocal clarity).",
-              "Apply moderate reduction: 2-4dB in the targeted frequency range."
-            ],
-            "body": "Traditional sidechain compression reduces the overall volume of a track, which can feel heavy-handed and obvious. Dynamic EQ sidechaining is a more surgical approach: it only reduces specific frequency ranges where masking occurs, leaving the rest of the track untouched. This creates transparent space without the 'pumping' artifacts of full-range sidechain compression.\n\nFor example, if your lead vocal is being masked by guitars in the 2-3kHz range, you don't need to compress the entire guitar track—you only need to reduce that specific frequency band when the vocal is present. The guitars' low end, high-end sparkle, and overall punch remain intact. This is the approach modern mix engineers use for professional pop and rock productions.\n\nSetup using FabFilter Pro-Q 3 (the industry-standard dynamic EQ with sidechain):\n\n1. Insert Pro-Q 3 on the track that needs frequency space reduction (e.g., rhythm guitars, pads, or a music bus).\n\n2. Enable a dynamic EQ band by clicking a band point and setting its type to 'Dynamic' (the lightning bolt icon).\n\n3. Set the band's frequency to the range where masking occurs. For vocal clarity, try 1.5-3kHz. For kick-bass separation, try 60-100Hz.\n\n4. Set the band's Q (width) to moderate—not too narrow (which sounds surgical and obvious) but not too wide (which affects too much frequency range). Start with Q around 2-4.\n\n5. In Pro-Q 3's sidechain section (bottom of the interface), set the external sidechain input to your triggering track (e.g., lead vocal).\n\n6. Adjust the dynamic band's threshold and range. Threshold determines how loud the trigger signal must be before reduction happens. Range determines how much reduction is applied (typically 2-4dB for transparency, up to 6-8dB for more obvious ducking).\n\n7. The result: when the vocal sings, the guitars' 2-3kHz range ducks by 3dB, creating space for vocal intelligibility. But the guitars' low-end body and high-end sparkle remain unchanged. The listener hears clear vocals without noticing any compression or pumping.\n\nFor Logic Pro users without third-party dynamic EQ:\n- Use Logic's Multipressor as a workaround: split the frequency spectrum into bands, then use external sidechain on the band(s) you want to duck. This is less elegant than Pro-Q 3 but effective.\n- Alternatively, use Trackspacer (a dedicated sidechain dynamic EQ plugin) which automatically analyzes the trigger signal and carves out space in the target track.\n- Or use standard sidechain compression with a sidechain EQ filter (covered in Step 11) to make the compressor only 'hear' specific frequencies. This is less precise than true dynamic EQ but can work for simple cases.\n\nDynamic EQ sidechaining is particularly useful for:\n- Vocal clarity in dense pop/rock mixes.\n- Podcast/voiceover where you want to duck music's midrange without affecting bass and treble.\n- Kick-bass separation where you want to duck the bass's 60-80Hz fundamental without affecting its upper harmonics.\n- Reducing sibilance clashes between lead and backing vocals (duck the backing vocals' 6-8kHz range when the lead vocal is present).",
-            "symbolName": "waveform.path.ecg",
-            "visualTitle": "Dynamic EQ Sidechain",
-            "visualCaption": "Target frequencies, not entire tracks.",
-            "settings": {
-              "Common Ranges": "Vocals: 1.5-3kHz, Kick-Bass: 60-100Hz, Sibilance: 6-8kHz",
-              "Reduction Amount": "2-4dB for transparency, 6-8dB for obvious space",
-              "Q (Width)": "2-4 (moderate, musical)",
-              "Tools": "FabFilter Pro-Q 3, Waves F6, Trackspacer, iZotope Neutron"
-            },
-            "proTip": "Use Pro-Q 3's real-time analyzer to visually identify exactly which frequency range is causing masking, then place your dynamic EQ band right on that peak.",
-            "avoidThis": "Don't use overly narrow Q values (10+) which create surgical, obvious dips. Dynamic EQ should be felt, not heard.",
-            "checkYourWork": "Your lead element (vocal, kick, etc.) is clear and present, but the overall tonal balance of supporting tracks remains unchanged. The space creation is transparent.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step9_dynamic_eq.png"
-          },
-          {
-            "number": 10,
-            "title": "Multiband Sidechain Compression",
-            "concept": "Splitting audio into frequency bands and sidechaining only specific bands preserves tonal balance while creating targeted dynamic space.",
-            "actions": [
-              "Use Logic's Multipressor or a third-party multiband compressor.",
-              "Split the frequency spectrum (e.g., Low: <200Hz, Mid: 200-5kHz, High: >5kHz).",
-              "Enable external sidechain on the band(s) you want to duck (typically Low or Mid).",
-              "Leave other bands untouched or use gentle settings."
-            ],
-            "body": "Multiband sidechain compression combines the best aspects of full-range sidechain and dynamic EQ: it splits audio into multiple frequency bands, then applies sidechain compression only to the bands where you need it. This is more flexible than standard sidechain (which affects everything) and easier to set up than dynamic EQ (which requires precision frequency selection).\n\nCommon applications:\n\n**Low-End Ducking:** Sidechain only the low band (<150Hz) of a bass track to the kick, leaving the bass's midrange and harmonic content untouched. This creates kick-bass separation without losing the 'warmth' and 'body' of the bass tone.\n\n**Vocal Clarity:** Sidechain only the midrange band (1-4kHz) of a music bus to the vocal, leaving lows and highs intact. This creates vocal space without affecting the bass or high-frequency shimmer.\n\n**Podcast/VO Ducking:** Sidechain the midrange band of background music to dialogue, leaving the music's bass and treble at full volume. This maintains musical richness while ensuring speech clarity.\n\nSetup in Logic Pro using Multipressor:\n\n1. Insert Logic's Multipressor on the target track (the one that should be affected).\n\n2. Set up your crossover points to split the frequency spectrum. For kick-bass example: Low band up to 150Hz, Mid band 150Hz to 5kHz, High band above 5kHz.\n\n3. For each band you want to sidechain, click the band's settings and enable the external sidechain input. Set it to your trigger track (e.g., kick drum).\n\n4. Configure the compression settings for each sidechained band:\n   - Low band (for kick-bass): Ratio 4:1-6:1, fast attack (0.1ms), moderate release (80-150ms), threshold for 3-6dB GR.\n   - Mid band (for vocal clarity): Ratio 3:1-4:1, 5-10ms attack, 100-200ms release, threshold for 2-4dB GR.\n\n5. Leave bands you don't want to duck either bypassed or set to very gentle settings.\n\n6. The result: you get targeted frequency-specific ducking without affecting the entire tonal balance of the track.\n\nThird-party multiband compressors with better sidechain features:\n- **FabFilter Pro-MB**: Offers up to 6 bands with individual sidechain inputs, per-band attack/release, and excellent visual feedback.\n- **Waves C6**: Industry-standard multiband with sidechain on each band.\n- **iZotope Ozone Dynamics**: Multiband mode with sidechain, often used for mastering-style multiband ducking.\n\nMultiband sidechaining is especially powerful when:\n- You want the benefits of dynamic EQ sidechaining but don't want to invest in FabFilter Pro-Q 3.\n- You need different ducking behavior in different frequency ranges (e.g., aggressive ducking in the lows, gentle ducking in the mids, no ducking in the highs).\n- You're working with complex, full-bandwidth sources (like synth pads or guitar buses) where simple full-range compression would be too heavy-handed.",
-            "symbolName": "square.split.diagonal",
-            "visualTitle": "Multiband Sidechain",
-            "visualCaption": "Frequency-specific ducking with tonal preservation.",
-            "settings": {
-              "Low Band": "<150Hz (kick-bass separation)",
-              "Mid Band": "150Hz-5kHz (vocal clarity)",
-              "High Band": ">5kHz (usually left alone)",
-              "Tools": "Logic Multipressor, FabFilter Pro-MB, Waves C6"
-            },
-            "proTip": "Use multiband sidechain on synth pads and atmospheric elements—duck only the mids for vocal space while leaving the lush low-end sub and high-end shimmer untouched.",
-            "avoidThis": "Don't sidechain all bands equally—that's just standard sidechain with extra CPU load. Use multiband specifically to target problem frequency ranges.",
-            "checkYourWork": "You've created space in the critical frequency range (e.g., low end for kick, mids for vocal) without altering the overall tonal character of the track.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step10_multiband_sidechain.png"
-          },
-          {
-            "number": 11,
-            "title": "Sidechain EQ Filtering for Targeted Triggering",
-            "concept": "Using the sidechain input's built-in EQ filter makes the compressor respond only to specific frequencies, creating more musical and transparent results.",
-            "actions": [
-              "In your sidechain compressor, locate the 'Filter' or 'Side Chain EQ' section.",
-              "Enable filtering and choose a filter type (high-pass, low-pass, or bandpass).",
-              "Set the filter frequency to isolate the trigger signal's most relevant range.",
-              "Test and adjust—the compressor should now respond only to filtered frequencies."
-            ],
-            "body": "By default, when you set up sidechain compression, the compressor 'listens' to the full frequency spectrum of the trigger track. But often, only certain frequencies are relevant. For kick-bass ducking, you only care about the kick's low-frequency thump (40-100Hz), not its high-frequency click. For vocal sidechaining, you only care about the vocal's intelligibility range (1-4kHz), not its breath noise or sibilance.\n\nLogic Pro's Compressor includes a built-in 'Side Chain' filter section that lets you EQ the sidechain input, making the compressor respond only to the frequencies you choose. This creates more musical, transparent compression with fewer artifacts.\n\nCommon filter applications:\n\n**High-Pass Filter (HPF):** Makes the compressor ignore low frequencies. Use this when sidechaining to vocals or dialogue to prevent plosives, breath noise, and low-frequency rumble from triggering compression. Set the HPF to 80-150Hz so the compressor only 'hears' the actual speech/vocal tone.\n\n**Low-Pass Filter (LPF):** Makes the compressor ignore high frequencies. Use this when sidechaining bass to kick—set an LPF around 120-200Hz so the compressor only responds to the kick's fundamental thump, not its beater click or cymbal bleed.\n\n**Bandpass Filter (BPF):** Makes the compressor only 'hear' a specific frequency range. Use this for surgical applications: for example, set a bandpass around 2-3kHz when sidechaining a music bus to vocals, so the compressor only responds to the core vocal intelligibility range.\n\n**Parametric EQ:** Some compressors (including Logic's) offer a parametric bell filter in the sidechain. Use this to emphasize a specific frequency that should trigger compression more strongly. For example, boost 60Hz in the sidechain when compressing bass to kick, making the compressor extra-sensitive to the kick's fundamental.\n\nSetup in Logic Pro's Compressor:\n\n1. Set up your sidechain compression as usual (compressor on target track, sidechain input set to trigger track).\n\n2. In the Compressor interface, locate the 'Side Chain' section (usually collapsed—click the disclosure triangle to expand it).\n\n3. Enable the 'Filter' checkbox.\n\n4. Choose your filter type from the drop-down: LP (low-pass), BP (bandpass), HP (high-pass), ParEQ (parametric), or HS (high shelf).\n\n5. Adjust the filter frequency and Q (width) to target your desired range. For example:\n   - Kick-bass with LPF: Set frequency to 150Hz so only low-end triggers compression.\n   - Vocal clarity with BPF: Set center frequency to 2.5kHz, Q around 1.5, so only vocal presence range triggers compression.\n   - Dialogue ducking with HPF: Set frequency to 100Hz to ignore rumble and plosives.\n\n6. Listen and adjust. The compressor's behavior will change—it should now respond more musically and predictably because it's only 'hearing' the relevant frequencies.\n\nThis technique is incredibly powerful but often overlooked. It can transform overly aggressive sidechain compression into smooth, musical ducking simply by making the compressor ignore irrelevant frequency content.\n\nThird-party compressors often have even more sophisticated sidechain filtering:\n- **FabFilter Pro-C 2:** Includes a built-in sidechain EQ with full parametric controls and real-time spectrum analysis.\n- **Waves Renaissance Compressor:** Offers sidechain high-pass and low-pass filters.\n- **SSL Native Bus Compressor:** Includes the famous SSL sidechain filter controls (SC HPF).",
-            "symbolName": "slider.vertical.3",
-            "visualTitle": "Sidechain Filter Control",
-            "visualCaption": "Make compressor respond only to relevant frequencies.",
-            "settings": {
-              "HPF (vocal/dialogue)": "80-150Hz (ignore rumble)",
-              "LPF (kick-bass)": "120-200Hz (only thump triggers)",
-              "BPF (vocal clarity)": "2-3kHz center (presence range)",
-              "ParEQ": "Boost or cut to emphasize specific triggers"
-            },
-            "proTip": "Use FabFilter Pro-C 2's sidechain audition feature (headphone icon) to solo what the compressor is 'hearing'—this makes dialing in the perfect filter setting instant and obvious.",
-            "avoidThis": "Don't use extremely narrow bandpass filters (Q > 10) unless you have a very specific reason—this can make the compressor respond inconsistently as the trigger track's frequency content varies.",
-            "checkYourWork": "Your sidechain compression responds smoothly and predictably, with fewer false triggers and more musical ducking that follows the most important elements of the trigger signal.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step11_sidechain_filter.png"
-          },
-          {
-            "number": 12,
-            "title": "Gate Sidechaining for Rhythmic Effects",
-            "concept": "Using a sidechain-triggered gate creates rhythmic chopping, stuttering, and on/off effects synchronized to a trigger track.",
-            "actions": [
-              "Insert Logic's Noise Gate on the track you want to rhythmically chop.",
-              "Set the gate's sidechain input to a rhythmic trigger (kick, hi-hat, or dedicated trigger track).",
-              "Use fast attack (0.1ms), adjust threshold for full gating, and set hold/release for desired effect length.",
-              "Create dramatic rhythmic effects synchronized to another element."
-            ],
-            "body": "While most sidechaining discussions focus on compression (which reduces volume), gate sidechaining is equally powerful for creative production. A noise gate silences audio when the trigger signal is below a threshold—when sidechained, this means the target track only plays when the trigger is present. This creates rhythmic chopping, stuttering, and gating effects that are perfectly locked to another element's rhythm.\n\nCommon creative applications:\n\n**Rhythmic Pad Gating:** Sidechain a lush pad or string sound to a kick or hi-hat pattern. The pad will only play when the trigger hits, creating a rhythmic, pulsing texture instead of a sustained drone. This is common in trance, techno, and progressive house.\n\n**Vocal Chopping:** Sidechain a vocal sample to a rhythmic MIDI trigger track (silent, used only for triggering). Create a MIDI pattern with the rhythm you want, then use it to 'slice' the vocal into rhythmic fragments.\n\n**Bass Gating:** Sidechain a sustained bass note to a kick or hi-hat. The bass will play in sync with the drums, creating a staccato, rhythmic bass line from what was originally a long sustained note.\n\n**Reverse Ducking (Creative Effect):** Use a gate sidechained to kick to make a synth or pad *only* play when the kick hits, creating a pumping effect that's the opposite of standard sidechain compression.\n\nSetup:\n\n1. Insert Logic's Noise Gate on the track you want to rhythmically chop (target).\n\n2. Set the gate's 'Side Chain' input to your trigger track (kick, hi-hat, or a dedicated MIDI trigger track).\n\n3. Configure the gate:\n   - Threshold: Set high enough that the target track is fully gated (silent) when the trigger is not present. You'll need to adjust by ear—start around -20dB and increase until you hear complete silence between triggers.\n   - Attack: Set to fastest (0.1ms) for instant gating, or slower (10-50ms) for a fade-in effect on each gate opening.\n   - Hold: Determines how long the gate stays open after the trigger stops. For short, staccato effects, use 10-50ms. For longer, more sustained gates, use 100-300ms.\n   - Release: How quickly the gate closes (fades out) after the hold time. Fast release (10-50ms) creates abrupt cuts. Slower release (100-300ms) creates smooth fade-outs.\n\n4. Test different trigger sources:\n   - Sidechain to kick for four-on-the-floor rhythmic gating.\n   - Sidechain to hi-hats for faster, more intricate rhythmic patterns.\n   - Sidechain to a custom MIDI trigger track for complete rhythmic control.\n\n5. Experiment with attack/hold/release to shape the character of the gating. Short settings create stuttering, glitchy effects. Long settings create smooth, pulsing textures.\n\nAdvanced techniques:\n- Use the gate's 'Hysteresis' control (if available) to prevent flutter when the trigger signal is near the threshold.\n- Combine gate sidechaining with volume automation for hybrid effects: gate for rhythmic structure, automation for musical phrasing.\n- Use a multiband gate (or split your signal into bands and gate each separately) for frequency-specific rhythmic gating—for example, gate only the midrange of a pad while leaving bass and treble sustained.\n\nGate sidechaining is less common in traditional mixing but extremely popular in electronic production, sound design, and remix work. It's a fast way to create complex rhythmic patterns from static, sustained sounds.\n\nThird-party gate plugins with advanced sidechain features:\n- **FabFilter Pro-G:** Industry-standard gate with sidechain input, per-band gating, and visual metering.\n- **Waves Renaissance DeEsser/Gate:** Classic gate with sidechain.\n- **Logic's own Enveloper:** While not technically a gate, it can be sidechained and used for similar rhythmic effects.",
-            "symbolName": "bolt.horizontal.circle",
-            "visualTitle": "Rhythmic Gate Sidechain",
-            "visualCaption": "Chop and slice in sync with triggers.",
-            "settings": {
-              "Attack": "0.1ms (instant) or 10-50ms (fade-in)",
-              "Hold": "10-50ms (staccato) or 100-300ms (sustained)",
-              "Release": "10-50ms (abrupt) or 100-300ms (smooth)",
-              "Threshold": "Adjust for complete gating"
-            },
-            "proTip": "Create a dedicated MIDI trigger track with no sound output—just MIDI notes—then use it to sidechain-gate any audio track. This gives you complete rhythmic control without being tied to existing drum patterns.",
-            "avoidThis": "Don't use gate sidechaining on lead vocals or primary melodic elements in traditional mixes—it's too destructive. Reserve it for creative production and sound design.",
-            "checkYourWork": "Your target track plays only when the trigger is active, creating a tight, rhythmic effect that's perfectly locked to the groove. The gating is clean without clicks or artifacts.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step12_gate_sidechain.png"
-          },
-          {
-            "number": 13,
-            "title": "Creative Auto-Filter Sidechaining",
-            "concept": "Sidechain-triggered auto-filters create dynamic tone changes synchronized to other tracks, useful for rhythmic filtering and movement.",
-            "actions": [
-              "Insert Logic's Auto Filter on the track you want to affect.",
-              "Set the filter type (low-pass, high-pass, or bandpass) and configure cutoff/resonance.",
-              "Enable sidechain input and select your trigger track.",
-              "Adjust envelope controls to shape how the filter responds to the trigger."
-            ],
-            "body": "Beyond compression and gating, Logic Pro's Auto Filter plugin supports sidechain input, allowing filter cutoff to be modulated by external audio sources. This creates dynamic, rhythmic filtering effects where a track's tone changes in response to another element—common in electronic music, dub, and creative sound design.\n\nApplications:\n\n**Rhythmic Low-Pass Filtering:** Sidechain a synth pad's Auto Filter to the kick. The pad's brightness increases when the kick hits, then dulls between kicks, creating rhythmic movement.\n\n**Dub-Style High-Pass Sweeps:** Sidechain a bass or guitar's Auto Filter to a hi-hat or shaker. The filter opens and closes rhythmically, creating classic dub/reggae filtering effects.\n\n**Dynamic Vocal Effects:** Sidechain a doubled vocal or harmony's Auto Filter to the lead vocal. The doubled vocal's tone shifts when the lead sings, creating space and movement.\n\nSetup:\n\n1. Insert Logic's Auto Filter on your target track.\n\n2. Choose a filter type:\n   - Low-Pass (LP): Typical for rhythmic brightness changes.\n   - High-Pass (HP): Useful for creating 'thinning' effects synchronized to triggers.\n   - Band-Pass (BP): For more dramatic, sweeping tonal shifts.\n\n3. Set the cutoff frequency and resonance to taste. Higher resonance creates more pronounced filter 'sweep' character.\n\n4. Enable the Auto Filter's external sidechain input and select your trigger track.\n\n5. Adjust the envelope and dynamics controls:\n   - Attack: How quickly the filter opens when triggered.\n   - Release: How quickly the filter closes after the trigger stops.\n   - Amount: How much the filter cutoff moves (the range of the sweep).\n\n6. The result: when your trigger plays, the filter cutoff moves, changing the target track's tone in sync with the trigger's rhythm.\n\nThis technique is less common in traditional mixing but extremely powerful for:\n- Creating movement and interest in static, sustained sounds (pads, drones).\n- Adding rhythmic complexity without additional instruments.\n- Dub production and remix work where filter sweeps are a core aesthetic element.\n\nAdvanced variations:\n- Combine auto-filter sidechaining with standard sidechain compression for hybrid effects: the track ducks in volume *and* tone simultaneously.\n- Use automation to change the filter's cutoff frequency over time while the sidechain controls the dynamic movement.\n- Route multiple tracks through a bus with a sidechain auto-filter for cohesive, ensemble filtering effects.",
-            "symbolName": "waveform.path.badge.minus",
-            "visualTitle": "Auto-Filter Sidechain",
-            "visualCaption": "Dynamic tone changes synchronized to triggers.",
-            "settings": {
-              "Filter Type": "Low-Pass (brighten/dull), High-Pass (thin/full), Band-Pass (sweeps)",
-              "Cutoff & Resonance": "Set base tone character",
-              "Sidechain Amount": "Controls depth of filter modulation",
-              "Envelope": "Attack/Release shape the filter movement"
-            },
-            "proTip": "Use subtle auto-filter sidechaining on background vocals or doubled instruments to create space for lead elements without obvious volume ducking—the tonal shift is often less noticeable than compression.",
-            "avoidThis": "Don't apply heavy resonance with fast sidechain triggering—this can create harsh, whistling artifacts. Keep resonance moderate for musical results.",
-            "checkYourWork": "Your target track's tone changes rhythmically in sync with the trigger, creating movement and interest without artifacts or harshness.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step13_autofilter_sidechain.png"
-          },
-          {
-            "number": 14,
-            "title": "Troubleshooting Common Sidechaining Problems",
-            "concept": "Understanding common artifacts and issues—pumping, clicks, inconsistent triggering, and over-compression—helps you achieve clean, professional results.",
-            "actions": [
-              "Identify audible artifacts: clicks, pumping, distortion, or loss of energy.",
-              "Check attack/release times: too fast causes clicks, too slow causes sluggish response.",
-              "Verify threshold and ratio: ensure gain reduction is appropriate for the task.",
-              "Use sidechain filtering or dynamic EQ to prevent false triggers."
-            ],
-            "body": "Even with proper setup, sidechain compression can introduce unwanted artifacts or fail to work as intended. Here are the most common problems and their solutions:\n\n**Problem 1: Audible Clicking or Popping**\n- Cause: Attack time is too fast (especially <1ms) or release is too fast with high gain reduction.\n- Solution: Increase attack to 3-10ms for smoother envelope response. Increase release to at least 50ms. Use soft knee for gentler compression onset.\n\n**Problem 2: Obvious, Unmusical Pumping**\n- Cause: Too much gain reduction (10dB+), or release time is out of sync with the track's rhythm.\n- Solution: Reduce ratio (from 8:1 down to 4:1), raise threshold to reduce gain reduction, or adjust release time so the compressor recovers musically (try tempo-synced release). For transparent mixing, aim for 2-6dB GR, not 10dB+.\n\n**Problem 3: Inconsistent or Weak Triggering**\n- Cause: Trigger signal is too quiet, or sidechain filtering is removing the relevant frequencies.\n- Solution: Check that your trigger track (e.g., kick) is actually loud enough to cross the threshold. Disable sidechain filtering temporarily to verify. If the trigger is a drum bus with multiple elements, consider using just the isolated kick for cleaner triggering.\n\n**Problem 4: Compressor Always Compressing (No Recovery)**\n- Cause: Threshold is set too low, or release is too long.\n- Solution: Raise the threshold so the compressor only engages when the trigger actually plays. Shorten release time so the compressor recovers between triggers. Check the gain-reduction meter—it should return to zero between triggers.\n\n**Problem 5: Loss of Energy or 'Dead' Sound**\n- Cause: Too much compression, or you've sidechained too many elements simultaneously.\n- Solution: Reduce the number of sidechained tracks—keep some elements stable for mix energy. Use multiband or dynamic EQ sidechaining instead of full-range compression to preserve tonal balance. Check makeup gain—though typically not needed for sidechaining, extremely heavy compression may benefit from a small amount to restore perceived loudness.\n\n**Problem 6: Distortion or Harsh Artifacts**\n- Cause: Over-compression with high ratio and low threshold, or compressor topology mismatch (some compressors add color/saturation that clashes with the source).\n- Solution: Switch compressor types—use a clean VCA or digital compressor instead of a colored Opto or FET model. Reduce ratio and increase threshold. Use multiband sidechaining to avoid compressing already-distorted frequency ranges.\n\n**Problem 7: Sidechain Not Working At All**\n- Cause: Sidechain routing is incorrect, or plugin doesn't support external sidechain.\n- Solution: Verify the sidechain input is actually set to your trigger track (check the 'Side Chain' menu in the compressor). Ensure the trigger track contains audio and isn't muted or soloed in a way that bypasses the sidechain send. Verify the compressor plugin supports external sidechain (Logic's stock Compressor does; some third-party plugins may not).\n\n**Problem 8: Phase Cancellation or Hollow Sound**\n- Cause: When using parallel or bus-based sidechaining, the sidechained element and non-sidechained elements may be out of phase, especially in the low end.\n- Solution: Use Logic's Gain Utility plugin to flip phase on one of the elements. Check correlation metering. Avoid heavy sidechain compression on low-end elements if phase issues persist—use dynamic EQ or multiband instead.\n\nGeneral troubleshooting workflow:\n1. Bypass the sidechain compressor and compare. If the 'improved' version sounds worse, reduce the intensity or rethink the approach.\n2. Solo the affected track and listen for artifacts (clicks, pumping, distortion) without the rest of the mix.\n3. Check the gain-reduction meter—it should respond rhythmically and predictably. If it's erratic or constantly pinned, your settings need adjustment.\n4. Test in mono. Sidechaining issues (especially phase problems) often become more obvious in mono playback.\n5. Take a break. Ear fatigue makes artifacts harder to identify. Fresh ears catch problems quickly.",
-            "symbolName": "wrench.and.screwdriver",
-            "visualTitle": "Troubleshooting Guide",
-            "visualCaption": "Identify and fix common artifacts.",
-            "settings": {
-              "Clicks": "Increase attack/release, use soft knee",
-              "Pumping": "Reduce ratio, raise threshold, adjust release timing",
-              "Weak Triggering": "Check trigger level, disable sidechain filter",
-              "Always Compressing": "Raise threshold, shorten release",
-              "Distortion": "Lower ratio, switch compressor type"
-            },
-            "proTip": "Create a 'test session' with a simple kick and bass to dial in your preferred sidechain settings. Save these as compressor presets you can recall in future projects.",
-            "avoidThis": "Don't keep adding more compression or stacking multiple sidechain compressors to 'fix' problems—often the solution is less compression, better settings, or a different approach (like dynamic EQ).",
-            "checkYourWork": "Your sidechain compression is transparent and musical (for mixing) or intentionally obvious (for creative effects), with no audible clicks, distortion, or unnatural pumping.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step14_troubleshooting.png"
-          },
-          {
-            "number": 15,
-            "title": "Advanced Workflow: Bus-Based Sidechaining",
-            "concept": "Routing multiple tracks to buses for cohesive sidechain behavior reduces CPU load and creates unified ducking across track groups.",
-            "actions": [
-              "Group related tracks (synths, guitars, pads) onto a bus.",
-              "Apply sidechain compression to the bus instead of individual tracks.",
-              "Use separate buses for different instrument families with unique sidechain needs.",
-              "Reduce CPU load while maintaining consistent, musical ducking."
-            ],
-            "body": "When mixing complex sessions with many tracks, applying individual sidechain compressors to each track is inefficient and can create inconsistent ducking where different elements pump at different rates. Bus-based sidechaining solves this by grouping related tracks onto auxiliary buses and applying a single sidechain compressor to each bus. This creates cohesive, unified ducking and significantly reduces CPU load.\n\nCommon bus groupings for sidechaining:\n\n**Melodic Bus:** Route all synths, keys, pads, and melodic instruments to one aux. Sidechain this bus to the lead vocal for transparent vocal clarity across all melodic content.\n\n**Rhythm Bus (non-kick/bass):** Route percussion, hi-hats, shakers, and rhythm elements to one aux. Sidechain to kick for EDM-style pumping that affects rhythmic layers but not the bass.\n\n**Background Vocal Bus:** Route all backing vocals and harmonies to one aux. Sidechain to lead vocal for automatic space creation without affecting individual backing vocal levels.\n\n**Pad Bus:** Route all atmospheric pads, strings, and ambient textures to one aux. Sidechain to drums or vocal for breathing space in dense sections.\n\nSetup workflow:\n\n1. Identify which tracks have similar sidechaining needs (same trigger source, similar compression settings).\n\n2. Create an auxiliary track for the group. Name it descriptively (e.g., 'Melodic Bus - SC').\n\n3. Route all relevant tracks to this aux by setting their output to the aux bus.\n\n4. Insert a compressor on the aux track and configure sidechain input and settings as usual.\n\n5. The entire group now ducks together, creating cohesive movement. If one synth needs different ducking, split it to a separate bus with unique settings.\n\nBenefits:\n- **CPU Efficiency:** One compressor instance instead of five or ten.\n- **Cohesion:** All elements in the bus duck together, creating unified movement rather than individual pumping.\n- **Mix Glue:** Bus-based sidechaining naturally groups elements sonically, helping them feel like they belong together.\n- **Easier Automation:** You can automate the bus's sidechain intensity (via threshold or ratio) to create dynamic changes (e.g., heavy pumping in the chorus, light pumping in the verse) without touching individual tracks.\n\nAdvanced variations:\n- Use **multiple buses** with different sidechain settings: a 'Heavy SC Bus' for tracks that should pump obviously, and a 'Light SC Bus' for tracks that need subtle ducking.\n- **Parallel sidechain processing:** Route tracks to both a sidechained bus and a non-sidechained bus, then blend them for hybrid ducking intensity.\n- **Nested buses:** Create a master 'Music Bus' with moderate sidechaining, then create sub-buses (guitars, keys, pads) with individual sidechain settings. This gives you both broad and surgical control.\n\nThis approach is standard in professional pop, EDM, and film mixing. It's how engineers manage complex sessions with dozens of tracks while maintaining CPU efficiency and mix cohesion.",
-            "symbolName": "point.3.filled.connected.trianglepath.dotted",
-            "visualTitle": "Bus-Based Sidechaining",
-            "visualCaption": "Group tracks for cohesive ducking.",
-            "settings": {
-              "Melodic Bus": "All synths/keys/melodic → sidechain to vocal",
-              "Rhythm Bus": "All perc (non-kick) → sidechain to kick",
-              "Pad Bus": "All pads/strings → sidechain to drums/vocal",
-              "BG Vocal Bus": "All backing vocals → sidechain to lead vocal"
-            },
-            "proTip": "Create color-coded track labels for sidechained buses so you can quickly identify which elements are being affected at a glance in large sessions.",
-            "avoidThis": "Don't route your entire mix (including drums and bass) to a single sidechained bus—this creates unstable, pumping mixes. Only route elements that genuinely need ducking.",
-            "checkYourWork": "Related tracks duck together as a cohesive group, creating unified movement. CPU load is reduced compared to individual track-by-track sidechaining.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step15_bus_routing.png"
-          },
-          {
-            "number": 16,
-            "title": "Sidechaining in Different Genres",
-            "concept": "Different musical genres have distinct sidechaining conventions—understanding genre expectations helps you apply appropriate techniques.",
-            "actions": [
-              "Identify genre-specific sidechaining norms (transparent for pop/rock, obvious for EDM, functional for podcasts).",
-              "Adjust intensity based on genre: subtle for acoustic/jazz, moderate for pop/hip-hop, extreme for EDM.",
-              "Study reference tracks in your genre to understand sidechaining conventions.",
-              "Balance technical needs (clarity) with creative expectations (pumping)."
-            ],
-            "body": "Sidechaining is not one-size-fits-all. Each genre has different conventions, expectations, and intensity levels. Understanding these norms helps you apply sidechaining appropriately and avoid genre-inappropriate choices.\n\n**Pop Music:**\n- **Approach:** Transparent to moderate. Sidechaining is used for vocal clarity (music bus method) and subtle low-end management (kick-bass ducking).\n- **Settings:** 2:1 to 4:1 ratio, 2-6dB gain reduction, moderate attack/release.\n- **Goal:** Vocals clear and upfront, low end tight, but no obvious pumping. Listeners shouldn't consciously notice the ducking.\n- **Reference:** Taylor Swift, The Weeknd, Ariana Grande—vocals are effortlessly clear without sounding disconnected.\n\n**EDM / Electronic Dance Music (House, Trance, Techno, Future Bass):**\n- **Approach:** Obvious and aggressive. Sidechaining is a production element, not just a mix tool. Heavy pumping creates energy and movement.\n- **Settings:** 8:1 to ∞:1 ratio, 10-15dB+ gain reduction, fast attack (0.1ms), tempo-synced release.\n- **Goal:** Dramatic, rhythmic pumping that grooves with the kick. The effect is intentional and central to the genre's sound.\n- **Reference:** Daft Punk ('One More Time'), Deadmau5, Calvin Harris—obvious pumping on pads, synths, and bass.\n\n**Hip-Hop / Trap:**\n- **Approach:** Moderate kick-bass sidechaining for low-end clarity. Minimal or no sidechaining on melodic elements unless the beat is heavily electronic.\n- **Settings:** 3:1 to 6:1 ratio, 3-6dB gain reduction on bass, fast attack, moderate release.\n- **Goal:** Kick hits hard and clear without fighting the 808 bass. Upper mix stays stable.\n- **Reference:** Metro Boomin, Travis Scott, Drake—tight low end, but no obvious pumping in the melodic content.\n\n**Rock / Indie:**\n- **Approach:** Subtle or none. Rock mixes traditionally use EQ, panning, and arrangement for separation. Sidechaining is less common and should be transparent if used.\n- **Settings:** If used, 2:1 to 3:1 ratio, 1-3dB gain reduction, gentle settings.\n- **Goal:** Maintain natural dynamics and energy. Sidechaining should solve specific masking issues without altering the genre's organic feel.\n- **Reference:** Foo Fighters, Arctic Monkeys—separation through EQ and arrangement, not obvious ducking.\n\n**Podcast / Voiceover / Film:**\n- **Approach:** Functional and aggressive. Dialogue is always priority one. Background music and ambience must duck clearly when speech is present.\n- **Settings:** 8:1 to ∞:1 ratio, 6-12dB gain reduction, instant attack, moderate release (200-500ms).\n- **Goal:** 100% dialogue intelligibility without listener effort. Ducking is expected and accepted.\n- **Reference:** Professional podcasts (The Daily, Radiolab), film dialogue—music always yields to speech.\n\n**Acoustic / Jazz / Classical:**\n- **Approach:** Minimal or none. These genres prioritize natural dynamics, live performance feel, and organic separation. Sidechaining is rare and should be nearly inaudible if used.\n- **Settings:** If absolutely needed, 1.5:1 to 2:1 ratio, 1-2dB gain reduction, very gentle.\n- **Goal:** Preserve natural performance dynamics. Use traditional mixing techniques (EQ, level balance) instead of heavy processing.\n- **Reference:** Most acoustic and jazz recordings avoid sidechaining entirely.\n\n**Dub / Reggae:**\n- **Approach:** Creative and rhythmic. Sidechaining (especially gate sidechaining and auto-filter sidechaining) is used for dub effects, rhythmic filtering, and space creation.\n- **Settings:** Varies widely—can be subtle or extreme depending on the effect. Often uses gating and filtering instead of compression.\n- **Goal:** Create rhythmic, pulsing textures that are part of the genre's aesthetic.\n- **Reference:** King Tubby, Lee 'Scratch' Perry—heavy use of rhythmic gating and filtering.\n\nKey takeaway: Always reference professional tracks in your genre before applying sidechaining. What's essential in EDM would be inappropriate in jazz. What's subtle in pop would be invisible in house music. Matching genre expectations is as important as technical execution.",
-            "symbolName": "music.quarternote.3",
-            "visualTitle": "Genre-Specific Sidechaining",
-            "visualCaption": "Different genres, different intensity.",
-            "settings": {
-              "Pop": "Transparent, 2-6dB GR, vocal clarity focus",
-              "EDM": "Obvious, 10-15dB+ GR, rhythmic pumping",
-              "Hip-Hop": "Moderate, 3-6dB GR, kick-bass only",
-              "Rock": "Minimal, 1-3dB GR or none, natural dynamics",
-              "Podcast": "Aggressive, 6-12dB GR, dialogue priority"
-            },
-            "proTip": "Create genre-specific compressor presets with appropriate settings for pop, EDM, hip-hop, etc., so you can quickly apply genre-appropriate sidechaining in future projects.",
-            "avoidThis": "Don't apply heavy EDM-style pumping to rock or acoustic genres—it will sound unnatural and out of place. Match your sidechaining intensity to genre conventions.",
-            "checkYourWork": "Your sidechaining matches the intensity and character expected in your genre. If unsure, A/B your mix against professional references.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step16_genre_comparison.png"
-          },
-          {
-            "number": 17,
-            "title": "Automating Sidechain Intensity",
-            "concept": "Automating sidechain parameters across song sections creates dynamic intensity changes—subtle in verses, heavy in choruses—for evolving energy.",
-            "actions": [
-              "Identify sections where sidechain intensity should change (e.g., lighter verse, heavier chorus).",
-              "Automate the compressor's threshold, ratio, or mix control.",
-              "Use snapshots or automation lanes to create smooth transitions.",
-              "Match sidechain intensity to arrangement density and energy."
-            ],
-            "body": "Static sidechain settings throughout an entire song can feel monotonous or inappropriate—verses may need subtle ducking while choruses benefit from heavier pumping. Automating sidechain parameters lets you dynamically adjust intensity to match the song's emotional and arrangement arc.\n\nCommon automation targets:\n\n**Threshold Automation:** Raising the threshold reduces how much the compressor engages (less ducking). Lowering it increases ducking. Automate threshold up during verses for minimal pumping, down during choruses for obvious pumping.\n\n**Ratio Automation:** Lower ratio (2:1 to 4:1) for transparent sections, higher ratio (6:1 to 10:1) for aggressive sections. This changes the intensity of gain reduction without altering when the compressor engages.\n\n**Mix Control Automation (Parallel Sidechaining):** Many compressors offer a 'Mix' or 'Dry/Wet' control that blends the compressed signal with the unprocessed signal. Automate this from 0% (no sidechaining) in quiet sections to 100% (full sidechaining) in heavy sections.\n\n**Attack/Release Automation:** Less common, but you can automate attack/release for changing character—fast attack in verses for tight control, slower attack in choruses for more natural pumping.\n\nWorkflow:\n\n1. Set up your sidechain compression with settings appropriate for the most intense section (usually the chorus or drop).\n\n2. In Logic Pro's automation view, enable automation for the parameter you want to control (threshold, ratio, or mix).\n\n3. Create automation lanes for each section:\n   - Intro: Minimal sidechaining (high threshold or low mix)\n   - Verse: Subtle sidechaining (moderate threshold)\n   - Pre-Chorus: Building intensity (lower threshold)\n   - Chorus: Maximum sidechaining (lowest threshold or highest mix)\n   - Bridge: Variable based on arrangement\n   - Outro: Fade sidechaining intensity to match energy decline\n\n4. Use smooth automation curves (not abrupt steps) to avoid audible jumps. Write gradual transitions that happen over 1-2 bars before section changes.\n\n5. Test the entire song to ensure the sidechain intensity feels musical and supports the arrangement's energy arc.\n\nThis technique is standard in professional pop and EDM production. Choruses often have obvious pumping while verses are clean and stable. This dynamic intensity change reinforces the song's structure and creates evolving energy that keeps listeners engaged.\n\nAdvanced approaches:\n- **Automation Snapshots:** Save different compressor settings as snapshots, then automate switching between them at section boundaries.\n- **Bus-Level Automation:** If using bus-based sidechaining (Step 15), automate the bus compressor's parameters for cohesive intensity changes across all grouped tracks.\n- **Parallel Sidechaining:** Create two buses—one heavily sidechained, one not. Automate the balance between them for smooth intensity transitions.",
-            "symbolName": "slider.horizontal.2.rectangle.and.arrow.triangle.2.circlepath",
-            "visualTitle": "Automating Sidechain Intensity",
-            "visualCaption": "Dynamic ducking that evolves with the song.",
-            "settings": {
-              "Threshold Automation": "High (less ducking) → Low (more ducking)",
-              "Ratio Automation": "2:1 (subtle) → 8:1 (obvious)",
-              "Mix Automation": "0% (off) → 100% (full effect)",
-              "Section-Based": "Verse: subtle, Chorus: heavy"
-            },
-            "proTip": "Automate sidechain intensity to build energy into drops and breakdowns—increase pumping gradually over 8-16 bars leading into a drop for maximum impact.",
-            "avoidThis": "Don't create abrupt, stepped automation changes—sudden shifts in sidechain intensity sound unnatural. Use smooth, gradual curves.",
-            "checkYourWork": "Sidechain intensity changes feel musical and support the song's structure. Verses are stable, choruses have appropriate energy, and transitions are smooth.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step17_automation.png"
-          },
-          {
-            "number": 18,
-            "title": "Parallel Sidechaining: Blending Ducked and Unducked Signals",
-            "concept": "Blending a sidechained version of a track with the unprocessed original creates controlled ducking without losing energy or presence.",
-            "actions": [
-              "Duplicate your target track or route it to a parallel aux.",
-              "Apply aggressive sidechain compression to the duplicate/aux.",
-              "Blend the heavily ducked signal with the dry original for hybrid control.",
-              "Adjust the balance to achieve the desired ducking intensity."
-            ],
-            "body": "Parallel sidechaining is a technique where you blend a heavily sidechained version of a track with the original, unprocessed version. This creates a hybrid sound where you get the clarity and space benefits of sidechaining without completely losing the track's energy and presence. It's especially useful for maintaining low-end power while still allowing kick clarity.\n\nConcept:\n- The original track stays at full volume, maintaining energy and presence.\n- The sidechained duplicate ducks dramatically when the trigger (e.g., kick) plays.\n- Blending the two creates a sound that's 'mostly there' but with subtle ducking—less obvious than pure sidechain compression, but more effective than no sidechaining.\n\nSetup Method 1: Duplicate Track\n\n1. Duplicate your target track (e.g., bass). Name one 'Bass Dry' and one 'Bass SC.'\n\n2. On the 'Bass SC' track, apply aggressive sidechain compression (8:1 ratio, 10-15dB gain reduction, fast attack, tempo-synced release).\n\n3. Leave the 'Bass Dry' track completely unprocessed (no sidechaining).\n\n4. Balance the two tracks by adjusting their faders:\n   - More 'Bass Dry' = more energy, less ducking.\n   - More 'Bass SC' = more obvious ducking, cleaner kick-bass interaction.\n   - Typical balance: 60% dry, 40% sidechained, but adjust to taste.\n\n5. Group the two tracks for easy level control.\n\nSetup Method 2: Aux Send (True Parallel)\n\n1. Keep your bass track at full volume with no sidechaining.\n\n2. Create an auxiliary track. Name it 'Bass SC Parallel.'\n\n3. Insert an aggressive sidechain compressor on the aux, sidechained to your kick.\n\n4. Send your bass track to this aux via a post-fader send.\n\n5. Blend the aux return level to taste—lower for subtle parallel ducking, higher for more obvious effect.\n\nBenefits:\n- **Maintains Energy:** The dry signal keeps the track feeling powerful and present.\n- **Provides Clarity:** The sidechained signal creates space for the kick without sacrificing too much low-end fullness.\n- **Adjustable Intensity:** You can dial in exactly how much ducking you want by adjusting the blend.\n- **Cleaner Than Moderate Settings:** Often cleaner and more musical than trying to find the 'perfect' moderate sidechain settings on a single track.\n\nApplications:\n- **Kick-Bass:** Parallel sidechaining maintains bass power while allowing kick clarity.\n- **Vocal Clarity:** Blend a heavily ducked music bus with a lightly ducked (or undocked) version for subtle vocal space without obvious pumping.\n- **Creative Pumping:** Use extreme sidechaining on the parallel channel for obvious pumping while the dry signal keeps the track grounded.\n\nAdvanced variations:\n- **Multiband Parallel:** Apply heavy low-end sidechaining on the parallel channel while leaving mids/highs dry.\n- **Frequency-Split Parallel:** Duplicate the track, high-pass the dry version (keeping only upper harmonics), low-pass the sidechained version (keeping only the fundamental), then blend. This lets the bass's 'body' stay present while only the fundamental ducks.\n- **NY Compression + Sidechain:** Combine traditional parallel compression (for density) with parallel sidechaining (for space) for hybrid control.",
-            "symbolName": "arrow.triangle.branch",
-            "visualTitle": "Parallel Sidechaining",
-            "visualCaption": "Blend ducked and dry for hybrid control.",
-            "settings": {
-              "Dry Signal": "100% level, no processing",
-              "Sidechained Signal": "Aggressive settings (8:1, 10-15dB GR)",
-              "Typical Blend": "60% dry, 40% sidechained (adjust to taste)",
-              "Method": "Duplicate track or aux send/return"
-            },
-            "proTip": "Use parallel sidechaining when standard sidechain settings feel either too subtle or too aggressive—the blend gives you precise control in the 'middle ground.'",
-            "avoidThis": "Don't add processing (EQ, reverb, etc.) to only one of the parallel signals unless intentional—this can create phase or tonal imbalance. Keep both clean or process identically.",
-            "checkYourWork": "Your track maintains energy and presence while still creating space for the trigger (e.g., kick clarity without losing bass power).",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step18_parallel_sidechain.png"
-          },
-          {
-            "number": 19,
-            "title": "Using Ghost Triggers for Creative Control",
-            "concept": "Creating a silent 'ghost' trigger track—MIDI or audio—gives you complete control over sidechain rhythm without being tied to existing arrangement elements.",
-            "actions": [
-              "Create a new MIDI or audio track that outputs no sound (muted or routed to nowhere).",
-              "Program the exact rhythm you want for sidechain triggering.",
-              "Use this ghost track as the sidechain input for your compressor/gate.",
-              "Adjust the ghost track's rhythm independently of the actual arrangement."
-            ],
-            "body": "Most sidechaining uses existing arrangement elements—kick drum, hi-hat, vocal—as the trigger. But sometimes you want sidechain ducking or gating to follow a rhythm that doesn't exist in your arrangement. Ghost triggers (also called 'phantom' or 'dummy' triggers) solve this by creating a silent track whose sole purpose is to trigger sidechain processing.\n\nApplications:\n\n**Custom Rhythmic Patterns:** Create complex, syncopated pumping rhythms that aren't tied to your kick drum. For example, trigger sidechain ducking on every eighth note, creating a faster pump than the quarter-note kick provides.\n\n**Gate Sidechaining for Vocal Chopping:** Program a MIDI rhythm that 'slices' a sustained vocal into rhythmic fragments, creating stutter and glitch effects.\n\n**Independent Control:** Change the sidechain rhythm without altering the actual kick drum or drum pattern in your mix.\n\n**Pre-Production Experimentation:** Set up ghost triggers early in production to test different pumping rhythms before committing to a drum pattern.\n\nSetup Method 1: MIDI Ghost Trigger\n\n1. Create a new software instrument track in Logic Pro.\n\n2. Load a simple, percussive instrument (like Ultrabeat or a single drum sample in EXS24) or even leave it empty.\n\n3. Mute the track's output: set the track's output to 'No Output' or reduce its fader to -∞.\n\n4. Program a MIDI pattern with the exact rhythm you want for sidechain triggering. For example, quarter-note triggers, sixteenth-note hi-hat patterns, or syncopated rhythms.\n\n5. In your sidechain compressor (on the target track), set the sidechain input to this ghost MIDI track.\n\n6. The compressor will 'hear' the ghost track's rhythm and duck accordingly, even though the ghost track produces no audible sound in the mix.\n\nSetup Method 2: Audio Ghost Trigger\n\n1. Create a new audio track.\n\n2. Route its output to an unused bus (not the Stereo Output) so it produces no audible sound.\n\n3. Place audio regions (like a kick sample) with the desired rhythm.\n\n4. Use this audio track as the sidechain input for your compressor/gate.\n\nBenefits:\n- **Flexibility:** You can edit the ghost track's rhythm independently without affecting the actual arrangement.\n- **Experimentation:** Try different sidechain rhythms instantly by editing the ghost track's MIDI or audio.\n- **Precision:** Create exact, quantized, or custom rhythms that don't depend on live drum performance timing.\n- **Layered Sidechaining:** Use multiple ghost triggers with different rhythms for different sidechain targets (one ghost for kick-style pumping, another for hi-hat-style gating).\n\nAdvanced techniques:\n- **Ghost Velocity Automation:** Program MIDI velocity changes on the ghost track to create dynamic sidechain intensity—louder ghost notes trigger more compression, quieter notes trigger less.\n- **Ghost Track Effects:** Apply effects (reverb, delay) to the ghost trigger (before muting its output) to create 'smeared' or 'trailing' sidechain triggers for experimental effects.\n- **Multiple Ghost Tracks:** Create separate ghost triggers for different sidechain targets—one for kick-style pumping (quarter notes), one for hi-hat gating (sixteenth notes), one for custom rhythmic effects.",
-            "symbolName": "waveform.badge.magnifyingglass",
-            "visualTitle": "Ghost Trigger Control",
-            "visualCaption": "Silent trigger tracks for custom rhythms.",
-            "settings": {
-              "MIDI Ghost": "Software instrument track, output muted or to 'No Output'",
-              "Audio Ghost": "Audio track routed to unused bus (not Stereo Out)",
-              "Rhythm": "Program exact pattern for sidechain triggering",
-              "Use Cases": "Custom pumping, vocal chopping, experimental gating"
-            },
-            "proTip": "Use a simple, short sample (like a single kick or click) on your ghost trigger track for clean, consistent triggering. Avoid complex, sustained sounds which may cause erratic compressor response.",
-            "avoidThis": "Don't forget to mute or re-route the ghost track's output—if it's audible in your mix, it will create unwanted clicks or drum sounds.",
-            "checkYourWork": "Your sidechain processing follows the exact custom rhythm you programmed, independent of the actual arrangement. The ghost track produces no audible sound.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step19_ghost_trigger.png"
-          },
-          {
-            "number": 20,
-            "title": "Final Checklist and Best Practices",
-            "concept": "A final review of sidechaining best practices ensures your implementation is clean, musical, and appropriate for your production goals.",
-            "actions": [
-              "Review all sidechain instances to verify appropriate intensity and settings.",
-              "Check for artifacts: clicks, pumping, distortion, or unnatural movement.",
-              "Test your mix in mono, at low volume, and on multiple playback systems.",
-              "Verify sidechain processing serves the music, not just the technique."
-            ],
-            "body": "Before finalizing your mix, run through this comprehensive sidechaining checklist to ensure professional results:\n\n**1. Verify Signal Routing:**\n- Confirm every sidechain compressor/gate is receiving the correct trigger source.\n- Check that target tracks are being affected (watch the gain-reduction meter).\n- Ensure no accidental routing to Stereo Out or unintended buses.\n\n**2. Check for Artifacts:**\n- Listen for clicks or pops (indicates attack/release too fast).\n- Listen for harsh, unmusical pumping (reduce ratio or raise threshold).\n- Listen for distortion or harshness (reduce gain reduction or change compressor type).\n- Listen for phase issues or hollow sound (check correlation meter, especially in mono).\n\n**3. Test Across Playback Systems:**\n- Check in mono: does the sidechaining translate well or cause problems?\n- Check at low volume: is the ducking still audible and appropriate?\n- Check on earbuds/phone speakers: does the low-end management still work?\n- Check on studio monitors: is the effect too obvious or too subtle?\n\n**4. Verify Musical Appropriateness:**\n- Does the sidechaining support the genre? (Transparent for pop, obvious for EDM, functional for podcasts)\n- Does it support the song's energy arc? (Subtle in verses, heavier in choruses, or consistent throughout?)\n- Does it solve a real problem (masking, clutter, lack of space) or is it arbitrary?\n\n**5. Review Intensity Across All Instances:**\n- If using multiple sidechain compressors, do they all use appropriate settings for their role?\n- Are some elements over-sidechained (losing energy) while others are under-sidechained (still masking)?\n- Is the overall mix stable, or does excessive sidechaining make everything feel pumping and unstable?\n\n**6. Bypass Test:**\n- Bypass all sidechain compressors at once and compare to the sidechained version.\n- The sidechained version should sound clearly better (clearer, more spacious, better separation).\n- If bypassing sounds better, you've over-sidechained—reduce intensity or remove unnecessary instances.\n\n**7. CPU and Session Management:**\n- Verify CPU load is reasonable (bus-based sidechaining helps if CPU is high).\n- Name all sidechain compressors clearly ('SC to Kick,' 'SC to Vocal') for easy troubleshooting.\n- Document your sidechain routing in session notes if the session is complex.\n\n**8. Genre-Specific Final Checks:**\n- **Pop/Rock:** Vocals clear? Low end tight? No obvious pumping in melodic elements?\n- **EDM:** Pumping obvious and musical? Tempo-synced and groovy? Energy maintained?\n- **Hip-Hop:** Kick-bass separation clean? Upper mix stable?\n- **Podcast:** Dialogue 100% intelligible? Background ducks appropriately?\n\n**9. Automation Review:**\n- If using sidechain automation, verify smooth transitions between sections.\n- Ensure automation curves are gradual, not stepped (which causes audible jumps).\n\n**10. Final Reference Check:**\n- A/B your mix against professional references in your genre.\n- Does your sidechaining match the intensity and character of those references?\n\nBest Practices Summary:\n- **Start subtle, add intensity only if needed.** It's easier to add more sidechaining than to undo over-sidechaining.\n- **Use bus-based sidechaining** for CPU efficiency and cohesion in complex sessions.\n- **Match genre expectations.** Don't apply EDM pumping to jazz, or subtle pop sidechaining to house music.\n- **Use dynamic EQ or multiband sidechaining** for transparent, surgical space creation.\n- **Test in mono and at low volume** to verify translation.\n- **Sidechain EQ filtering** improves triggering consistency and reduces artifacts.\n- **Automate sidechain intensity** to match song sections and energy arc.\n- **Reference professional tracks** before finalizing your sidechaining decisions.\n\nSidechaining is one of the most powerful tools in modern mixing and production. When done well, it creates space, clarity, and movement that elevates your mix. When done poorly, it creates pumping, instability, and listener fatigue. Following this checklist ensures you land on the professional side of that divide.",
-            "symbolName": "checkmark.seal.fill",
-            "visualTitle": "Sidechaining Best Practices",
-            "visualCaption": "Final checklist for clean, professional results.",
-            "settings": {
-              "Routing": "Verify all sidechain sources and targets",
-              "Artifacts": "No clicks, harshness, or unnatural pumping",
-              "Translation": "Test mono, low volume, multiple systems",
-              "Musical Fit": "Supports genre, song structure, and energy",
-              "Bypass Test": "Sidechained version clearly better"
-            },
-            "proTip": "Create a 'Sidechain Template' session with pre-configured buses, compressors, and routing for your typical workflow. This speeds up future projects and ensures consistent, professional results.",
-            "avoidThis": "Don't assume your sidechaining is correct without testing—bypass and compare, check in mono, and verify on multiple systems before calling a mix finished.",
-            "checkYourWork": "Your sidechaining is clean, musical, genre-appropriate, and translates well across playback systems. It solves real problems without introducing new ones.",
-            "stepScreenshot": "/assets/training/sidechaining-complete-guide/step16_genre_comparison.png"
-          }
-        ]
-      },
-      {
-        "id": "parallel-busses",
-        "title": "Parallel Busses: Advanced Mixing Technique",
-        "series": "Advanced Mixing Series",
-        "summary": "Learn practical parallel routing in Logic Pro for compression, saturation, and time-based effects while preserving transient clarity and musical dynamics.",
-        "duration": "28 min read",
-        "symbolName": "arrow.triangle.branch",
-        "badges": [
-          "Advanced",
-          "Creative",
-          "Technique"
-        ],
-        "isFeatured": true,
-        "checklist": [
-          "Create dedicated parallel aux buses and name them clearly.",
-          "Use pre-fader sends when you need independent blend control.",
-          "Set up parallel compression to add density without flattening transients.",
-          "Use EQ on returns to keep low-end and harshness controlled.",
-          "Level-match and A/B returns against the dry signal.",
-          "Check phase and mono compatibility before finalizing."
-        ],
-        "steps": [
-          {
-            "number": 1,
-            "title": "Understand the Parallel Workflow",
-            "concept": "Parallel processing blends a heavily processed duplicate with the original to gain impact without sacrificing natural tone.",
-            "actions": [
-              "Keep your dry source intact.",
-              "Route a send to a dedicated aux return.",
-              "Blend processed return until it supports the source."
-            ],
-            "body": "This approach lets you use aggressive settings (compression, distortion, filtering) while preserving clarity from the dry path.",
-            "symbolName": "arrow.triangle.branch",
-            "visualTitle": "Dry + Processed Blend",
-            "visualCaption": "Power and control without destroying source detail.",
-            "settings": {
-              "Starting Blend": "10-30% return level",
-              "Signal Flow": "Dry track + aux return"
-            },
-            "proTip": "Set up reusable parallel aux templates for speed across sessions.",
-            "avoidThis": "Do not over-blend returns until the dry source disappears.",
-            "checkYourWork": "Bypassing the return reduces impact, but the mix still sounds natural.",
-            "stepScreenshot": "/assets/training/parallel-busses/step1_concept_diagram.png"
-          },
-          {
-            "number": 2,
-            "title": "Route Parallel Compression",
-            "concept": "Parallel compression adds body and sustain while leaving transient attack intact.",
-            "actions": [
-              "Send drum or vocal bus to an aux with a compressor.",
-              "Use higher ratio and deeper gain reduction than you would in serial mode.",
-              "Blend the return under the dry signal."
-            ],
-            "body": "On drums, this increases perceived power. On vocals, it can improve consistency and intelligibility in dense sections.",
-            "symbolName": "arrow.down.circle.fill",
-            "visualTitle": "Crush Then Blend",
-            "visualCaption": "Aggressive return, subtle mix contribution.",
-            "settings": {
-              "Typical Ratio": "6:1 to 12:1",
-              "Gain Reduction": "8-15 dB on return path"
-            },
-            "proTip": "Shape return tone with EQ after compression to avoid mud.",
-            "avoidThis": "Avoid stacking multiple parallel compressors without purpose.",
-            "checkYourWork": "The return adds energy and sustain without pumping artifacts.",
-            "stepScreenshot": "/assets/training/parallel-busses/step3_drum_compression.png"
-          },
-          {
-            "number": 3,
-            "title": "Use Parallel Reverb and Saturation",
-            "concept": "Parallel time and harmonic effects create size and color while maintaining source focus.",
-            "actions": [
-              "Use separate aux returns for short room, plate, and saturation.",
-              "Filter reverb returns to control low-end wash.",
-              "Automate return levels for transitions and choruses."
-            ],
-            "body": "Parallel reverbs improve depth without clouding the center. Parallel saturation improves perceived loudness and texture.",
-            "symbolName": "sparkles",
-            "visualTitle": "Depth and Harmonics",
-            "visualCaption": "Space and color under the dry signal.",
-            "settings": {
-              "HPF on Reverb Return": "150-300 Hz",
-              "Return Strategy": "Separate aux by effect type"
-            },
-            "proTip": "Short reverbs often read cleaner than long tails in busy arrangements.",
-            "avoidThis": "Do not feed every track into every return bus.",
-            "checkYourWork": "Mix feels wider and richer while lead elements stay clear.",
-            "stepScreenshot": "/assets/training/parallel-busses/step4_reverb_routing.png"
-          },
-          {
-            "number": 4,
-            "title": "Validate Phase and Translation",
-            "concept": "Parallel chains can introduce phase and masking if unchecked.",
-            "actions": [
-              "A/B dry-only vs blend at matched loudness.",
-              "Check mono fold-down for cancellations.",
-              "Trim return timing/phase if low-end weakens."
-            ],
-            "body": "Final checks ensure parallel benefits survive across speakers, headphones, and mono playback.",
-            "symbolName": "checkmark.seal.fill",
-            "visualTitle": "Final Safety Pass",
-            "visualCaption": "Phase-safe, mono-safe, mix-safe.",
-            "settings": {
-              "A/B Method": "Matched loudness comparison",
-              "Mono Check": "No major center collapse"
-            },
-            "proTip": "Keep one reference snapshot with all returns bypassed.",
-            "avoidThis": "Avoid judging return tone in solo for final decisions.",
-            "checkYourWork": "Parallel processing improves excitement and still translates cleanly.",
-            "stepScreenshot": "/assets/training/parallel-busses/step10_complete_workflow.png"
-          }
-        ]
-      },
-      {
-        "id": "stereo-tricks",
-        "title": "Stereo Tricks",
-        "series": "Advanced Mixing Techniques",
-        "summary": "Build width and depth with panning, mid-side decisions, Haas concepts, and stereo automation while keeping mono compatibility intact.",
-        "duration": "35 min read",
-        "symbolName": "speaker.wave.3.fill",
-        "badges": [
-          "Advanced",
-          "Professional",
-          "Mixing"
-        ],
-        "isFeatured": true,
-        "checklist": [
-          "Keep foundational elements anchored in the center.",
-          "Use panning symmetry to balance competing parts.",
-          "Apply width tools in controlled ranges.",
-          "Use stereo effects to support arrangement roles.",
-          "Automate width by section for energy changes.",
-          "Verify correlation and mono playback before bounce."
-        ],
-        "steps": [
-          {
-            "number": 1,
-            "title": "Map the Stereo Field",
-            "concept": "Intentional placement reduces masking and improves focus.",
-            "actions": [
-              "Center kick, bass, snare, and lead vocal.",
-              "Place support elements in balanced left/right positions.",
-              "Use fewer hard-pan choices than you think."
-            ],
-            "body": "A disciplined layout keeps the center stable while creating width from supporting instruments.",
-            "symbolName": "scope",
-            "visualTitle": "Stereo Layout",
-            "visualCaption": "Anchor core, spread support.",
-            "settings": {
-              "Core Elements": "Center",
-              "Support Range": "Moderate L/R offsets first"
-            },
-            "proTip": "Decide panning in context, not in solo.",
-            "avoidThis": "Do not leave both sides crowded with similar timbres.",
-            "checkYourWork": "Center remains strong while sides provide clear separation.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step1_stereo_field_basics.png"
-          },
-          {
-            "number": 2,
-            "title": "Use Width Tools Carefully",
-            "concept": "Stereo widening can help size, but overuse causes phase issues and weak mono translation.",
-            "actions": [
-              "Apply Direction Mixer or equivalent to non-foundational layers.",
-              "Increase width in small increments.",
-              "Monitor correlation while widening."
-            ],
-            "body": "Widening works best on pads, FX, doubles, and ambience, not bass-heavy or lead-anchor tracks.",
-            "symbolName": "arrow.left.and.right.righttriangle.left.righttriangle.right",
-            "visualTitle": "Controlled Widening",
-            "visualCaption": "Small moves, safer translation.",
-            "settings": {
-              "Typical Spread Range": "100-130%",
-              "Correlation Goal": "Stay safely above negative values"
-            },
-            "proTip": "If mono loses punch, pull width back before adding more EQ.",
-            "avoidThis": "Avoid widening everything in the same frequency range.",
-            "checkYourWork": "Stereo image feels larger, and mono still sounds solid.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step4_direction_mixer.png"
-          },
-          {
-            "number": 3,
-            "title": "Create Depth With Stereo FX",
-            "concept": "Short delays, subtle modulation, and filtered reverbs add depth without blurring articulation.",
-            "actions": [
-              "Use short stereo delays for spatial separation.",
-              "Filter returns to avoid low-end smear.",
-              "Balance wet effects by section density."
-            ],
-            "body": "Time-based stereo effects should support arrangement roles rather than compete with the center.",
-            "symbolName": "timelapse",
-            "visualTitle": "Depth Through Time",
-            "visualCaption": "Stereo space with articulation preserved.",
-            "settings": {
-              "Delay Use": "Short and level-controlled",
-              "Return EQ": "HPF/LPF to fit the mix"
-            },
-            "proTip": "Keep vocal clarity by ducking FX returns around key phrases.",
-            "avoidThis": "Do not use long, bright tails on every prominent element.",
-            "checkYourWork": "Mix sounds deeper and wider without turning hazy.",
-            "stepScreenshot": "/assets/training/stereo-tricks/step10_stereo_delay.png"
-          },
-          {
-            "number": 4,
-            "title": "Automate Width by Section",
-            "concept": "Width contrast between verse and chorus increases perceived impact.",
-            "actions": [
-              "Start verses narrower for intimacy.",
-              "Open choruses wider for lift and release.",
-              "Use smooth automation ramps at transitions."
-            ],
-            "body": "Dynamic width feels more musical than static maximum spread across the entire song.",
-            "symbolName": "waveform.path.badge.plus",
-            "visualTitle": "Section Contrast",
-            "visualCaption": "Narrow-to-wide movement adds energy.",
-            "settings": {
-              "Verse Spread": "80-100%",
-              "Chorus Spread": "120-140%"
-            },
-            "proTip": "Automate supporting buses, not every individual track first.",
-            "avoidThis": "Avoid abrupt width jumps that distract the listener.",
-            "checkYourWork": "Section changes feel larger while center remains stable.",
             "stepScreenshot": "/assets/training/stereo-tricks/step22_stereo_automation.png"
           }
         ]

--- a/public/content/en/manifest.json
+++ b/public/content/en/manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "contentVersion": "20260510T145536Z",
-  "generatedAt": "2026-05-10T14:55:36.758Z",
+  "contentVersion": "20260510T152015Z",
+  "generatedAt": "2026-05-10T15:20:15.884Z",
   "minAppVersion": "1.0.0",
   "bundle": {
     "url": "/content/en/content.json",
-    "sha256": "c1f89a552e57f622a09adc6bdce6144f9dd2bba80f4a946ac61536421f8465d1",
-    "bytes": 811726
+    "sha256": "69f896b70bcb7b2781d79405ee97e328a43741e365808b28ed727fda78e98c94",
+    "bytes": 891029
   }
 }

--- a/public/content/manifest.json
+++ b/public/content/manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "contentVersion": "20260510T145536Z",
-  "generatedAt": "2026-05-10T14:55:36.758Z",
+  "contentVersion": "20260510T152015Z",
+  "generatedAt": "2026-05-10T15:20:15.884Z",
   "minAppVersion": "1.0.0",
   "bundle": {
     "url": "/content/content.json",
-    "sha256": "c1f89a552e57f622a09adc6bdce6144f9dd2bba80f4a946ac61536421f8465d1",
-    "bytes": 811726
+    "sha256": "69f896b70bcb7b2781d79405ee97e328a43741e365808b28ed727fda78e98c94",
+    "bytes": 891029
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview
This PR adds an AI-powered assistant called "Logic Pro Guru" to help users with Logic Pro workflows, recording, mixing, and mastering questions.

## Features Implemented
✅ **Chat Interface**
- Clean, modern chat UI with message history
- Typing indicators and loading states
- Suggestion buttons for common questions
- Mobile-responsive design with dark mode support

✅ **AI Integration**
- OpenAI GPT-4 integration using Vercel AI SDK
- Custom system prompt tailored for Logic Pro beginners
- Streaming responses for real-time interaction
- Edge runtime for optimal performance

✅ **User Experience**
- Accessible from home page (embedded chat section)
- Dedicated `/assistant` page for full chat experience
- Added to navigation menu for easy access
- Message history maintained during session

## Technical Details
- **Backend**: API route at `/api/chat` using OpenAI and Vercel AI SDK
- **Frontend**: React component with `useChat` hook from `@ai-sdk/react`
- **Styling**: CSS matching the existing app design system
- **Dependencies**: Added `ai`, `openai`, `@ai-sdk/openai`, and `@ai-sdk/react`

## Configuration Required
The OpenAI API key must be configured:
1. Copy `.env.example` to `.env.local`
2. Add your OpenAI API key: `OPENAI_API_KEY=your-key-here`
3. For Vercel deployment, add the key in project settings

## Testing
- ✅ Build passes successfully
- ✅ TypeScript compilation with no errors
- ✅ Components render correctly on home page and dedicated page
- ✅ Navigation updated with AI Assistant link

## Documentation
- Updated README.md with feature description
- Updated README.md with environment setup instructions
- Created `.env.example` with OpenAI API key template

## Related Issue
Resolves LEV-19
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LEV-19](https://linear.app/levensailor/issue/LEV-19/add-ai-agent)

<div><a href="https://cursor.com/agents/bc-3ac215eb-6e3c-405d-97e8-bb38638897a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ac215eb-6e3c-405d-97e8-bb38638897a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

