### PR TITLE
Fix keyboard dismissal in iOS chat view

### DIFF
--- a/ios/LogicProCheatSheets/LogicProCheatSheets/Views/MainTabView.swift
+++ b/ios/LogicProCheatSheets/LogicProCheatSheets/Views/MainTabView.swift
@@ -91,6 +91,7 @@ private struct AssistantTabView: View {
 private struct AssistantChatView: View {
     @ObservedObject var viewModel: AssistantChatViewModel
     @State private var draft = ""
+    @FocusState private var isInputFocused: Bool
 
     private let suggestionPrompts = [
         "How do I build a good vocal chain in Logic Pro?",
@@ -163,6 +164,9 @@ private struct AssistantChatView: View {
             }
             .padding()
         }
+        .onTapGesture {
+            isInputFocused = false
+        }
     }
 
     private var conversationView: some View {
@@ -188,6 +192,10 @@ private struct AssistantChatView: View {
                 }
                 .padding()
             }
+            .scrollDismissesKeyboard(.interactively)
+            .onTapGesture {
+                isInputFocused = false
+            }
             .onChange(of: viewModel.messages.last?.id) {
                 guard let last = viewModel.messages.last else {
                     return
@@ -207,11 +215,21 @@ private struct AssistantChatView: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 10)
                 .background(.background, in: RoundedRectangle(cornerRadius: 14))
+                .focused($isInputFocused)
+                .toolbar {
+                    ToolbarItemGroup(placement: .keyboard) {
+                        Spacer()
+                        Button("Done") {
+                            isInputFocused = false
+                        }
+                    }
+                }
 
             Button {
                 let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { return }
                 draft = ""
+                isInputFocused = false
                 viewModel.send(text: text)
             } label: {
                 Image(systemName: "arrow.up.circle.fill")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes LEV-21: iOS users can now easily dismiss the keyboard and navigate out of the Guru chat view.

## Problem

When asking the Guru a question in the iOS app:
- The keyboard wouldn't dismiss, blocking access to navigation
- Swipe gestures didn't work to exit
- Users were trapped in the chat input

## Solution

Added multiple ways to dismiss the keyboard:

1. **Tap outside** - Tapping on the conversation or welcome area dismisses the keyboard
2. **Scroll gesture** - Dragging the conversation down interactively dismisses the keyboard
3. **Keyboard toolbar** - Added a "Done" button above the keyboard
4. **Auto-dismiss** - Keyboard dismisses automatically after sending a message

## Technical Changes

- Added `@FocusState` to track text field focus state
- Bound TextField to the focus state with `.focused($isInputFocused)`
- Added `.scrollDismissesKeyboard(.interactively)` to conversation ScrollView
- Added tap gestures to welcome and conversation views
- Added keyboard toolbar with Done button
- Dismiss keyboard when sending message

## Testing

Manual testing recommended:
1. Open the Guru tab
2. Tap the text field to bring up keyboard
3. Verify you can dismiss it by:
   - Tapping on the conversation area
   - Scrolling the conversation
   - Tapping the "Done" button above the keyboard
   - Sending a message
4. Verify swipe gestures work when keyboard is dismissed
5. Verify tab navigation is accessible when keyboard is dismissed
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LEV-21](https://linear.app/levensailor/issue/LEV-21/no-way-of-exiting-chat)

<div><a href="https://cursor.com/agents/bc-234c3af6-b7fd-48ed-9f87-f7482a1c42fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-234c3af6-b7fd-48ed-9f87-f7482a1c42fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

